### PR TITLE
Add input validation mixin to gcp operators.

### DIFF
--- a/airflow/contrib/operators/gcp_compute_operator.py
+++ b/airflow/contrib/operators/gcp_compute_operator.py
@@ -24,15 +24,19 @@ from airflow import AirflowException
 from airflow.contrib.hooks.gcp_compute_hook import GceHook
 from airflow.contrib.utils.gcp_field_sanitizer import GcpBodyFieldSanitizer
 from airflow.contrib.utils.gcp_field_validator import GcpBodyFieldValidator
+from airflow.contrib.utils.input_validator import InputValidationMixin
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from json_merge_patch import merge
 
 
-class GceBaseOperator(BaseOperator):
+class GceBaseOperator(BaseOperator, InputValidationMixin):
     """
     Abstract base operator for Google Compute Engine operators to inherit from.
     """
+
+    REQUIRED_ATTRIBUTES = ['zone', 'resource_id']
+    OPTIONAL_NOT_EMPTY_ATTRIBUTES = ['project_id']
 
     @apply_defaults
     def __init__(self,
@@ -50,14 +54,6 @@ class GceBaseOperator(BaseOperator):
         self._validate_inputs()
         self._hook = GceHook(gcp_conn_id=self.gcp_conn_id, api_version=self.api_version)
         super(GceBaseOperator, self).__init__(*args, **kwargs)
-
-    def _validate_inputs(self):
-        if self.project_id == '':
-            raise AirflowException("The required parameter 'project_id' is missing")
-        if not self.zone:
-            raise AirflowException("The required parameter 'zone' is missing")
-        if not self.resource_id:
-            raise AirflowException("The required parameter 'resource_id' is missing")
 
     def execute(self, context):
         pass

--- a/airflow/contrib/operators/gcp_sql_operator.py
+++ b/airflow/contrib/operators/gcp_sql_operator.py
@@ -21,6 +21,7 @@ from googleapiclient.errors import HttpError
 from airflow import AirflowException
 from airflow.contrib.hooks.gcp_sql_hook import CloudSqlHook, CloudSqlDatabaseHook
 from airflow.contrib.utils.gcp_field_validator import GcpBodyFieldValidator
+from airflow.contrib.utils.input_validator import InputValidationMixin
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.hooks.base_hook import BaseHook
@@ -133,7 +134,7 @@ CLOUD_SQL_DATABASE_PATCH_VALIDATION = [
 ]
 
 
-class CloudSqlBaseOperator(BaseOperator):
+class CloudSqlBaseOperator(BaseOperator, InputValidationMixin):
     """
     Abstract base operator for Google Cloud SQL operators to inherit from.
 
@@ -147,6 +148,10 @@ class CloudSqlBaseOperator(BaseOperator):
     :param api_version: API version used (e.g. v1beta4).
     :type api_version: str
     """
+
+    REQUIRED_ATTRIBUTES = ['instance']
+    OPTIONAL_NOT_EMPTY_ATTRIBUTES = ['project_id']
+
     @apply_defaults
     def __init__(self,
                  instance,
@@ -162,12 +167,6 @@ class CloudSqlBaseOperator(BaseOperator):
         self._hook = CloudSqlHook(gcp_conn_id=self.gcp_conn_id,
                                   api_version=self.api_version)
         super(CloudSqlBaseOperator, self).__init__(*args, **kwargs)
-
-    def _validate_inputs(self):
-        if self.project_id == '':
-            raise AirflowException("The required parameter 'project_id' is empty")
-        if not self.instance:
-            raise AirflowException("The required parameter 'instance' is empty or None")
 
     def _check_if_instance_exists(self, instance):
         try:
@@ -225,6 +224,8 @@ class CloudSqlInstanceCreateOperator(CloudSqlBaseOperator):
     template_fields = ('project_id', 'instance', 'gcp_conn_id', 'api_version')
     # [END gcp_sql_create_template_fields]
 
+    REQUIRED_ATTRIBUTES = ['instance', 'body']
+
     @apply_defaults
     def __init__(self,
                  body,
@@ -239,11 +240,6 @@ class CloudSqlInstanceCreateOperator(CloudSqlBaseOperator):
         super(CloudSqlInstanceCreateOperator, self).__init__(
             project_id=project_id, instance=instance, gcp_conn_id=gcp_conn_id,
             api_version=api_version, *args, **kwargs)
-
-    def _validate_inputs(self):
-        super(CloudSqlInstanceCreateOperator, self)._validate_inputs()
-        if not self.body:
-            raise AirflowException("The required parameter 'body' is empty")
 
     def _validate_body_fields(self):
         if self.validate_body:
@@ -295,6 +291,8 @@ class CloudSqlInstancePatchOperator(CloudSqlBaseOperator):
     template_fields = ('project_id', 'instance', 'gcp_conn_id', 'api_version')
     # [END gcp_sql_patch_template_fields]
 
+    REQUIRED_ATTRIBUTES = ['instance', 'body']
+
     @apply_defaults
     def __init__(self,
                  body,
@@ -307,11 +305,6 @@ class CloudSqlInstancePatchOperator(CloudSqlBaseOperator):
         super(CloudSqlInstancePatchOperator, self).__init__(
             project_id=project_id, instance=instance, gcp_conn_id=gcp_conn_id,
             api_version=api_version, *args, **kwargs)
-
-    def _validate_inputs(self):
-        super(CloudSqlInstancePatchOperator, self)._validate_inputs()
-        if not self.body:
-            raise AirflowException("The required parameter 'body' is empty")
 
     def execute(self, context):
         if not self._check_if_instance_exists(self.instance):
@@ -388,6 +381,8 @@ class CloudSqlInstanceDatabaseCreateOperator(CloudSqlBaseOperator):
     template_fields = ('project_id', 'instance', 'gcp_conn_id', 'api_version')
     # [END gcp_sql_db_create_template_fields]
 
+    REQUIRED_ATTRIBUTES = ['instance', 'body']
+
     @apply_defaults
     def __init__(self,
                  instance,
@@ -402,11 +397,6 @@ class CloudSqlInstanceDatabaseCreateOperator(CloudSqlBaseOperator):
         super(CloudSqlInstanceDatabaseCreateOperator, self).__init__(
             project_id=project_id, instance=instance, gcp_conn_id=gcp_conn_id,
             api_version=api_version, *args, **kwargs)
-
-    def _validate_inputs(self):
-        super(CloudSqlInstanceDatabaseCreateOperator, self)._validate_inputs()
-        if not self.body:
-            raise AirflowException("The required parameter 'body' is empty")
 
     def _validate_body_fields(self):
         if self.validate_body:
@@ -459,6 +449,8 @@ class CloudSqlInstanceDatabasePatchOperator(CloudSqlBaseOperator):
                        'api_version')
     # [END gcp_sql_db_patch_template_fields]
 
+    REQUIRED_ATTRIBUTES = ['instance', 'body', 'database']
+
     @apply_defaults
     def __init__(self,
                  instance,
@@ -475,13 +467,6 @@ class CloudSqlInstanceDatabasePatchOperator(CloudSqlBaseOperator):
         super(CloudSqlInstanceDatabasePatchOperator, self).__init__(
             project_id=project_id, instance=instance, gcp_conn_id=gcp_conn_id,
             api_version=api_version, *args, **kwargs)
-
-    def _validate_inputs(self):
-        super(CloudSqlInstanceDatabasePatchOperator, self)._validate_inputs()
-        if not self.body:
-            raise AirflowException("The required parameter 'body' is empty")
-        if not self.database:
-            raise AirflowException("The required parameter 'database' is empty")
 
     def _validate_body_fields(self):
         if self.validate_body:
@@ -524,6 +509,8 @@ class CloudSqlInstanceDatabaseDeleteOperator(CloudSqlBaseOperator):
                        'api_version')
     # [END gcp_sql_db_delete_template_fields]
 
+    REQUIRED_ATTRIBUTES = ['instance', 'database']
+
     @apply_defaults
     def __init__(self,
                  instance,
@@ -536,11 +523,6 @@ class CloudSqlInstanceDatabaseDeleteOperator(CloudSqlBaseOperator):
         super(CloudSqlInstanceDatabaseDeleteOperator, self).__init__(
             project_id=project_id, instance=instance, gcp_conn_id=gcp_conn_id,
             api_version=api_version, *args, **kwargs)
-
-    def _validate_inputs(self):
-        super(CloudSqlInstanceDatabaseDeleteOperator, self)._validate_inputs()
-        if not self.database:
-            raise AirflowException("The required parameter 'database' is empty")
 
     def execute(self, context):
         if not self._check_if_db_exists(self.database):
@@ -582,6 +564,8 @@ class CloudSqlInstanceExportOperator(CloudSqlBaseOperator):
     template_fields = ('project_id', 'instance', 'gcp_conn_id', 'api_version')
     # [END gcp_sql_export_template_fields]
 
+    REQUIRED_ATTRIBUTES = ['instance', 'body']
+
     @apply_defaults
     def __init__(self,
                  instance,
@@ -596,11 +580,6 @@ class CloudSqlInstanceExportOperator(CloudSqlBaseOperator):
         super(CloudSqlInstanceExportOperator, self).__init__(
             project_id=project_id, instance=instance, gcp_conn_id=gcp_conn_id,
             api_version=api_version, *args, **kwargs)
-
-    def _validate_inputs(self):
-        super(CloudSqlInstanceExportOperator, self)._validate_inputs()
-        if not self.body:
-            raise AirflowException("The required parameter 'body' is empty")
 
     def _validate_body_fields(self):
         if self.validate_body:
@@ -654,6 +633,8 @@ class CloudSqlInstanceImportOperator(CloudSqlBaseOperator):
     template_fields = ('project_id', 'instance', 'gcp_conn_id', 'api_version')
     # [END gcp_sql_import_template_fields]
 
+    REQUIRED_ATTRIBUTES = ['instance', 'body']
+
     @apply_defaults
     def __init__(self,
                  instance,
@@ -668,11 +649,6 @@ class CloudSqlInstanceImportOperator(CloudSqlBaseOperator):
         super(CloudSqlInstanceImportOperator, self).__init__(
             project_id=project_id, instance=instance, gcp_conn_id=gcp_conn_id,
             api_version=api_version, *args, **kwargs)
-
-    def _validate_inputs(self):
-        super(CloudSqlInstanceImportOperator, self)._validate_inputs()
-        if not self.body:
-            raise AirflowException("The required parameter 'body' is empty")
 
     def _validate_body_fields(self):
         if self.validate_body:

--- a/airflow/contrib/utils/input_validator.py
+++ b/airflow/contrib/utils/input_validator.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from airflow import AirflowException
+
+
+class InputValidationMixin(object):
+
+    REQUIRED_ATTRIBUTES = []
+    OPTIONAL_NOT_EMPTY_ATTRIBUTES = []
+
+    def _validate_inputs(self):
+        for attr_name in self.REQUIRED_ATTRIBUTES:
+            attr = getattr(self, attr_name)
+            if attr is None:
+                raise AirflowException("The required parameter '{}' is missing".format(attr_name))
+            if not attr:
+                raise AirflowException("The required parameter '{}' is empty".format(attr_name))
+        for attr_name in self.OPTIONAL_NOT_EMPTY_ATTRIBUTES:
+            attr = getattr(self, attr_name)
+            if attr is None:
+                # attribute is optional so None is OK
+                continue
+            if not attr:
+                raise AirflowException("The optional parameter '{}' is empty".format(attr_name))

--- a/tests/contrib/operators/test_gcp_compute_operator.py
+++ b/tests/contrib/operators/test_gcp_compute_operator.py
@@ -108,7 +108,7 @@ class GceInstanceStartTest(unittest.TestCase):
             )
             op.execute(None)
         err = cm.exception
-        self.assertIn("The required parameter 'project_id' is missing", str(err))
+        self.assertIn("The optional parameter 'project_id' is empty", str(err))
         mock_hook.assert_not_called()
 
     @mock.patch('airflow.contrib.operators.gcp_compute_operator.GceHook')
@@ -131,7 +131,7 @@ class GceInstanceStartTest(unittest.TestCase):
             )
             op.execute(None)
         err = cm.exception
-        self.assertIn("The required parameter 'zone' is missing", str(err))
+        self.assertIn("The required parameter 'zone' is empty", str(err))
         mock_hook.assert_not_called()
 
     @mock.patch('airflow.contrib.operators.gcp_compute_operator.GceHook')
@@ -145,7 +145,7 @@ class GceInstanceStartTest(unittest.TestCase):
             )
             op.execute(None)
         err = cm.exception
-        self.assertIn("The required parameter 'resource_id' is missing", str(err))
+        self.assertIn("The required parameter 'resource_id' is empty", str(err))
         mock_hook.assert_not_called()
 
 
@@ -203,7 +203,7 @@ class GceInstanceStopTest(unittest.TestCase):
             )
             op.execute(None)
         err = cm.exception
-        self.assertIn("The required parameter 'project_id' is missing", str(err))
+        self.assertIn("The optional parameter 'project_id' is empty", str(err))
         mock_hook.assert_not_called()
 
     @mock.patch('airflow.contrib.operators.gcp_compute_operator.GceHook')
@@ -231,7 +231,7 @@ class GceInstanceStopTest(unittest.TestCase):
             )
             op.execute(None)
         err = cm.exception
-        self.assertIn("The required parameter 'zone' is missing", str(err))
+        self.assertIn("The required parameter 'zone' is empty", str(err))
         mock_hook.assert_not_called()
 
     @mock.patch('airflow.contrib.operators.gcp_compute_operator.GceHook')
@@ -245,7 +245,7 @@ class GceInstanceStopTest(unittest.TestCase):
             )
             op.execute(None)
         err = cm.exception
-        self.assertIn("The required parameter 'resource_id' is missing", str(err))
+        self.assertIn("The required parameter 'resource_id' is empty", str(err))
         mock_hook.assert_not_called()
 
 
@@ -310,7 +310,7 @@ class GceInstanceSetMachineTypeTest(unittest.TestCase):
             )
             op.execute(None)
         err = cm.exception
-        self.assertIn("The required parameter 'project_id' is missing", str(err))
+        self.assertIn("The optional parameter 'project_id' is empty", str(err))
         mock_hook.assert_not_called()
 
     @mock.patch('airflow.contrib.operators.gcp_compute_operator.GceHook')
@@ -343,7 +343,7 @@ class GceInstanceSetMachineTypeTest(unittest.TestCase):
             )
             op.execute(None)
         err = cm.exception
-        self.assertIn("The required parameter 'zone' is missing", str(err))
+        self.assertIn("The required parameter 'zone' is empty", str(err))
         mock_hook.assert_not_called()
 
     @mock.patch('airflow.contrib.operators.gcp_compute_operator.GceHook')
@@ -358,7 +358,7 @@ class GceInstanceSetMachineTypeTest(unittest.TestCase):
             )
             op.execute(None)
         err = cm.exception
-        self.assertIn("The required parameter 'resource_id' is missing", str(err))
+        self.assertIn("The required parameter 'resource_id' is empty", str(err))
         mock_hook.assert_not_called()
 
     @mock.patch('airflow.contrib.operators.gcp_compute_operator.GceHook')

--- a/tests/contrib/operators/test_gcp_spanner_operator.py
+++ b/tests/contrib/operators/test_gcp_spanner_operator.py
@@ -159,8 +159,8 @@ class CloudSpannerTest(unittest.TestCase):
         self.assertIsNone(result)
 
     @parameterized.expand([
-        ("", INSTANCE_ID, "project_id"),
-        (PROJECT_ID, "", "instance_id"),
+        ("", INSTANCE_ID, ["optional", "project_id"]),
+        (PROJECT_ID, "", ["required", "instance_id"]),
     ])
     @mock.patch("airflow.contrib.operators.gcp_spanner_operator.CloudSpannerHook")
     def test_instance_create_ex_if_param_missing(self, project_id, instance_id,
@@ -175,7 +175,7 @@ class CloudSpannerTest(unittest.TestCase):
                 task_id="id"
             )
         err = cm.exception
-        self.assertIn("The required parameter '{}' is empty".format(exp_msg), str(err))
+        self.assertIn("The {} parameter '{}' is empty".format(exp_msg[0], exp_msg[1]), str(err))
         mock_hook.assert_not_called()
 
     @mock.patch("airflow.contrib.operators.gcp_spanner_operator.CloudSpannerHook")
@@ -223,8 +223,8 @@ class CloudSpannerTest(unittest.TestCase):
         self.assertTrue(result)
 
     @parameterized.expand([
-        ("", INSTANCE_ID, "project_id"),
-        (PROJECT_ID, "", "instance_id"),
+        ("", INSTANCE_ID, ["optional", "project_id"]),
+        (PROJECT_ID, "", ["required", "instance_id"]),
     ])
     @mock.patch("airflow.contrib.operators.gcp_spanner_operator.CloudSpannerHook")
     def test_instance_delete_ex_if_param_missing(self, project_id, instance_id, exp_msg,
@@ -236,7 +236,7 @@ class CloudSpannerTest(unittest.TestCase):
                 task_id="id"
             )
         err = cm.exception
-        self.assertIn("The required parameter '{}' is empty".format(exp_msg), str(err))
+        self.assertIn("The {} parameter '{}' is empty".format(exp_msg[0], exp_msg[1]), str(err))
         mock_hook.assert_not_called()
 
     @mock.patch("airflow.contrib.operators.gcp_spanner_operator.CloudSpannerHook")
@@ -276,10 +276,10 @@ class CloudSpannerTest(unittest.TestCase):
         self.assertIsNone(result)
 
     @parameterized.expand([
-        ("", INSTANCE_ID, DB_ID, INSERT_QUERY, "project_id"),
-        (PROJECT_ID, "", DB_ID, INSERT_QUERY, "instance_id"),
-        (PROJECT_ID, INSTANCE_ID, "", INSERT_QUERY, "database_id"),
-        (PROJECT_ID, INSTANCE_ID, DB_ID, "", "query"),
+        ("", INSTANCE_ID, DB_ID, INSERT_QUERY, ["optional", "project_id"]),
+        (PROJECT_ID, "", DB_ID, INSERT_QUERY, ["required", "instance_id"]),
+        (PROJECT_ID, INSTANCE_ID, "", INSERT_QUERY, ["required", "database_id"]),
+        (PROJECT_ID, INSTANCE_ID, DB_ID, "", ["required", "query"]),
     ])
     @mock.patch("airflow.contrib.operators.gcp_spanner_operator.CloudSpannerHook")
     def test_instance_query_ex_if_param_missing(self, project_id, instance_id,
@@ -293,7 +293,7 @@ class CloudSpannerTest(unittest.TestCase):
                 task_id="id"
             )
         err = cm.exception
-        self.assertIn("The required parameter '{}' is empty".format(exp_msg), str(err))
+        self.assertIn("The {} parameter '{}' is empty".format(exp_msg[0], exp_msg[1]), str(err))
         mock_hook.assert_not_called()
 
     @mock.patch("airflow.contrib.operators.gcp_spanner_operator.CloudSpannerHook")
@@ -383,9 +383,9 @@ class CloudSpannerTest(unittest.TestCase):
         self.assertTrue(result)
 
     @parameterized.expand([
-        ("", INSTANCE_ID, DB_ID, DDL_STATEMENTS, 'project_id'),
-        (PROJECT_ID, "", DB_ID, DDL_STATEMENTS, 'instance_id'),
-        (PROJECT_ID, INSTANCE_ID, "", DDL_STATEMENTS, 'database_id'),
+        ("", INSTANCE_ID, DB_ID, DDL_STATEMENTS, ['optional', 'project_id']),
+        (PROJECT_ID, "", DB_ID, DDL_STATEMENTS, ['required', 'instance_id']),
+        (PROJECT_ID, INSTANCE_ID, "", DDL_STATEMENTS, ['required', 'database_id']),
     ])
     @mock.patch("airflow.contrib.operators.gcp_spanner_operator.CloudSpannerHook")
     def test_database_create_ex_if_param_missing(self,
@@ -401,7 +401,7 @@ class CloudSpannerTest(unittest.TestCase):
                 task_id="id"
             )
         err = cm.exception
-        self.assertIn("The required parameter '{}' is empty".format(exp_msg), str(err))
+        self.assertIn("The {} parameter '{}' is empty".format(exp_msg[0], exp_msg[1]), str(err))
         mock_hook.assert_not_called()
 
     @mock.patch("airflow.contrib.operators.gcp_spanner_operator.CloudSpannerHook")
@@ -440,9 +440,9 @@ class CloudSpannerTest(unittest.TestCase):
         self.assertTrue(result)
 
     @parameterized.expand([
-        ("", INSTANCE_ID, DB_ID, DDL_STATEMENTS, 'project_id'),
-        (PROJECT_ID, "", DB_ID, DDL_STATEMENTS, 'instance_id'),
-        (PROJECT_ID, INSTANCE_ID, "", DDL_STATEMENTS, 'database_id'),
+        ("", INSTANCE_ID, DB_ID, DDL_STATEMENTS, ['optional', 'project_id']),
+        (PROJECT_ID, "", DB_ID, DDL_STATEMENTS, ['required', 'instance_id']),
+        (PROJECT_ID, INSTANCE_ID, "", DDL_STATEMENTS, ['required', 'database_id']),
     ])
     @mock.patch("airflow.contrib.operators.gcp_spanner_operator.CloudSpannerHook")
     def test_database_update_ex_if_param_missing(self, project_id, instance_id,
@@ -457,7 +457,7 @@ class CloudSpannerTest(unittest.TestCase):
                 task_id="id"
             )
         err = cm.exception
-        self.assertIn("The required parameter '{}' is empty".format(exp_msg), str(err))
+        self.assertIn("The {} parameter '{}' is empty".format(exp_msg[0], exp_msg[1]), str(err))
         mock_hook.assert_not_called()
 
     @mock.patch("airflow.contrib.operators.gcp_spanner_operator.CloudSpannerHook")
@@ -524,9 +524,9 @@ class CloudSpannerTest(unittest.TestCase):
         self.assertTrue(result)
 
     @parameterized.expand([
-        ("", INSTANCE_ID, DB_ID, DDL_STATEMENTS, 'project_id'),
-        (PROJECT_ID, "", DB_ID, DDL_STATEMENTS, 'instance_id'),
-        (PROJECT_ID, INSTANCE_ID, "", DDL_STATEMENTS, 'database_id'),
+        ("", INSTANCE_ID, DB_ID, DDL_STATEMENTS, ['optional', 'project_id']),
+        (PROJECT_ID, "", DB_ID, DDL_STATEMENTS, ['required', 'instance_id']),
+        (PROJECT_ID, INSTANCE_ID, "", DDL_STATEMENTS, ['required', 'database_id']),
     ])
     @mock.patch("airflow.contrib.operators.gcp_spanner_operator.CloudSpannerHook")
     def test_database_delete_ex_if_param_missing(self, project_id, instance_id,
@@ -541,5 +541,5 @@ class CloudSpannerTest(unittest.TestCase):
                 task_id="id"
             )
         err = cm.exception
-        self.assertIn("The required parameter '{}' is empty".format(exp_msg), str(err))
+        self.assertIn("The {} parameter '{}' is empty".format(exp_msg[0], exp_msg[1]), str(err))
         mock_hook.assert_not_called()

--- a/tests/contrib/operators/test_gcp_sql_operator.py
+++ b/tests/contrib/operators/test_gcp_sql_operator.py
@@ -242,7 +242,7 @@ class CloudSqlTest(unittest.TestCase):
             )
             op.execute(None)
         err = cm.exception
-        self.assertIn("The required parameter 'project_id' is empty", str(err))
+        self.assertIn("The optional parameter 'project_id' is empty", str(err))
         mock_hook.assert_not_called()
 
     @mock.patch("airflow.contrib.operators.gcp_sql_operator.CloudSqlHook")

--- a/tests/contrib/utils/test_input_validator.py
+++ b/tests/contrib/utils/test_input_validator.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import unittest
+
+from airflow import AirflowException
+from airflow.contrib.utils.input_validator import InputValidationMixin
+from airflow.models import BaseOperator
+
+
+class MockOperator(BaseOperator, InputValidationMixin):
+
+    REQUIRED_ATTRIBUTES = ['req']
+    OPTIONAL_NOT_EMPTY_ATTRIBUTES = ['opt']
+
+    def __init__(self, req, opt, *args, **kwargs):
+        self.req = req
+        self.opt = opt
+        self._validate_inputs()
+        super(MockOperator, self).__init__(*args, **kwargs)
+
+    def execute(self, context):
+        pass
+
+
+class InputValidatorTest(unittest.TestCase):
+
+    def test_missing_required_attribute(self):
+        with self.assertRaises(AirflowException) as cm:
+            MockOperator(req=None, opt='', task_id="id")
+        self.assertIn("The required parameter 'req' is missing", str(cm.exception))
+
+    def test_empty_required_attribute(self):
+        with self.assertRaises(AirflowException) as cm:
+            MockOperator(req={}, opt='', task_id="id")
+        self.assertIn("The required parameter 'req' is empty", str(cm.exception))
+
+    def test_empty_optional_attribute(self):
+        with self.assertRaises(AirflowException) as cm:
+            MockOperator(req="req", opt='', task_id="id")
+        self.assertIn("The optional parameter 'opt' is empty", str(cm.exception))
+
+    def test_missing_optional_attribute(self):
+        try:
+            MockOperator(req="req", opt=None, task_id="id")
+        except AirflowException:
+            self.fail("Should not throw exception for missing optional attributes")


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
