### PR TITLE
[PARKED] Move BigtableTableWaitForReplicationSensor to sensors package

### DIFF
--- a/airflow/contrib/example_dags/example_gcp_bigtable_operators.py
+++ b/airflow/contrib/example_dags/example_gcp_bigtable_operators.py
@@ -57,9 +57,9 @@ from airflow.contrib.operators.gcp_bigtable_operator import \
     BigtableInstanceDeleteOperator, \
     BigtableClusterUpdateOperator, \
     BigtableTableCreateOperator, \
-    BigtableTableWaitForReplicationSensor, \
     BigtableTableDeleteOperator
-
+from airflow.contrib.sensors.gcp_bigtable_sensor import \
+    BigtableTableWaitForReplicationSensor
 # [START howto_operator_gcp_bigtable_args]
 GCP_PROJECT_ID = getenv('GCP_PROJECT_ID', 'example-project')
 CBT_INSTANCE_ID = getenv('CBT_INSTANCE_ID', 'some-instance-id')

--- a/airflow/contrib/operators/gcp_bigtable_operator.py
+++ b/airflow/contrib/operators/gcp_bigtable_operator.py
@@ -21,11 +21,8 @@ import google.api_core.exceptions
 
 from airflow import AirflowException
 from airflow.models import BaseOperator
-from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.contrib.hooks.gcp_bigtable_hook import BigtableHook
 from airflow.utils.decorators import apply_defaults
-from google.cloud.bigtable_admin_v2 import enums
-from google.cloud.bigtable.table import ClusterState
 
 
 class BigtableValidationMixin(object):
@@ -395,66 +392,3 @@ class BigtableClusterUpdateOperator(BaseOperator, BigtableValidationMixin):
         except google.api_core.exceptions.GoogleAPICallError as e:
             self.log.error('An error occurred. Exiting.')
             raise e
-
-
-class BigtableTableWaitForReplicationSensor(BaseSensorOperator, BigtableValidationMixin):
-    """
-    Sensor that waits for Cloud Bigtable table to be fully replicated to its clusters.
-    No exception will be raised if the instance or the table does not exist.
-
-    For more details about cluster states for a table, have a look at the reference:
-    https://googleapis.github.io/google-cloud-python/latest/bigtable/table.html#google.cloud.bigtable.table.Table.get_cluster_states
-
-    :type instance_id: str
-    :param instance_id: The ID of the Cloud Bigtable instance.
-    :type table_id: str
-    :param table_id: The ID of the table to check replication status.
-    :type project_id: str
-    :param project_id: Optional, the ID of the GCP project.
-    """
-    REQUIRED_ATTRIBUTES = ('instance_id', 'table_id')
-    template_fields = ['project_id', 'instance_id', 'table_id']
-
-    @apply_defaults
-    def __init__(self,
-                 instance_id,
-                 table_id,
-                 project_id=None,
-                 *args, **kwargs):
-        self.project_id = project_id
-        self.instance_id = instance_id
-        self.table_id = table_id
-        self._validate_inputs()
-        self.hook = BigtableHook()
-        super(BigtableTableWaitForReplicationSensor, self).__init__(*args, **kwargs)
-
-    def poke(self, context):
-        instance = self.hook.get_instance(project_id=self.project_id,
-                                          instance_id=self.instance_id)
-        if not instance:
-            self.log.info("Dependency: instance '%s' does not exist.", self.instance_id)
-            return False
-
-        try:
-            cluster_states = self.hook.get_cluster_states_for_table(instance=instance,
-                                                                    table_id=self.table_id)
-        except google.api_core.exceptions.NotFound:
-            self.log.info(
-                "Dependency: table '%s' does not exist in instance '%s'.",
-                self.table_id, self.instance_id)
-            return False
-
-        ready_state = ClusterState(enums.Table.ClusterState.ReplicationState.READY)
-
-        is_table_replicated = True
-        for cluster_id in cluster_states.keys():
-            if cluster_states[cluster_id] != ready_state:
-                self.log.info("Table '%s' is not yet replicated on cluster '%s'.",
-                              self.table_id, cluster_id)
-                is_table_replicated = False
-
-        if not is_table_replicated:
-            return False
-
-        self.log.info("Table '%s' is replicated.", self.table_id)
-        return True

--- a/airflow/contrib/sensors/gcs_bigtable_sensor.py
+++ b/airflow/contrib/sensors/gcs_bigtable_sensor.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import google.api_core.exceptions
+
+from google.cloud.bigtable_admin_v2 import enums
+from google.cloud.bigtable.table import ClusterState
+
+from airflow.contrib.hooks.gcp_bigtable_hook import BigtableHook
+from airflow.contrib.operators.gcp_bigtable_operator import \
+    BigtableValidationMixin
+from airflow.sensors.base_sensor_operator import BaseSensorOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class BigtableTableWaitForReplicationSensor(BaseSensorOperator,
+                                            BigtableValidationMixin):
+    """
+    Sensor that waits for Cloud Bigtable table to be fully replicated to its
+    clusters.
+    No exception will be raised if the instance or the table does not exist.
+
+    For more details about cluster states for a table, have a look at
+    the reference:
+    https://googleapis.github.io/google-cloud-python/latest/bigtable/table.html#google.cloud.bigtable.table.Table.get_cluster_states
+
+    :type instance_id: str
+    :param instance_id: The ID of the Cloud Bigtable instance.
+    :type table_id: str
+    :param table_id: The ID of the table to check replication status.
+    :type project_id: str
+    :param project_id: Optional, the ID of the GCP project.
+    """
+    REQUIRED_ATTRIBUTES = ('instance_id', 'table_id')
+    template_fields = ['project_id', 'instance_id', 'table_id']
+
+    @apply_defaults
+    def __init__(self,
+                 instance_id,
+                 table_id,
+                 project_id=None,
+                 *args, **kwargs):
+        self.project_id = project_id
+        self.instance_id = instance_id
+        self.table_id = table_id
+        self._validate_inputs()
+        self.hook = BigtableHook()
+        super(BigtableTableWaitForReplicationSensor, self).__init__(*args,
+                                                                    **kwargs)
+
+    def poke(self, context):
+        instance = self.hook.get_instance(project_id=self.project_id,
+                                          instance_id=self.instance_id)
+        if not instance:
+            self.log.info("Dependency: instance '%s' does not exist.",
+                          self.instance_id)
+            return False
+
+        try:
+            cluster_states = self.hook.get_cluster_states_for_table(
+                instance=instance,
+                table_id=self.table_id
+            )
+        except google.api_core.exceptions.NotFound:
+            self.log.info(
+                "Dependency: table '%s' does not exist in instance '%s'.",
+                self.table_id, self.instance_id)
+            return False
+
+        ready_state = ClusterState(enums.Table.ClusterState.
+                                   ReplicationState.READY)
+
+        is_table_replicated = True
+        for cluster_id in cluster_states.keys():
+            if cluster_states[cluster_id] != ready_state:
+                self.log.info(
+                    "Table '%s' is not yet replicated on cluster '%s'.",
+                    self.table_id, cluster_id)
+                is_table_replicated = False
+
+        if not is_table_replicated:
+            return False
+
+        self.log.info("Table '%s' is replicated.", self.table_id)
+        return True

--- a/docs/howto/operator.rst
+++ b/docs/howto/operator.rst
@@ -544,7 +544,7 @@ BigtableTableWaitForReplicationSensor
 You can create the operator with or without project id. If project id is missing
 it will be retrieved from the GCP connection used. Both variants are shown:
 
-Use the :class:`~airflow.contrib.operators.gcp_bigtable_operator.BigtableTableWaitForReplicationSensor`
+Use the :class:`~airflow.contrib.sensors.gcp_bigtable_sensor.BigtableTableWaitForReplicationSensor`
 to wait for the table to replicate fully.
 
 The same arguments apply to this sensor as the BigtableTableCreateOperator_.

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -910,7 +910,7 @@ BigtableTableDeleteOperator
 BigtableTableWaitForReplicationSensor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autoclass:: airflow.contrib.operators.gcp_bigtable_operator.BigtableTableWaitForReplicationSensor
+.. autoclass:: airflow.contrib.sensors.gcp_bigtable_sensor.BigtableTableWaitForReplicationSensor
 
 .. _BigtableHook:
 

--- a/tests/contrib/operators/test_gcp_bigtable_operator.py
+++ b/tests/contrib/operators/test_gcp_bigtable_operator.py
@@ -29,9 +29,10 @@ from airflow.contrib.operators.gcp_bigtable_operator import \
     BigtableInstanceDeleteOperator, \
     BigtableTableDeleteOperator, \
     BigtableTableCreateOperator, \
-    BigtableTableWaitForReplicationSensor, \
     BigtableClusterUpdateOperator, \
     BigtableInstanceCreateOperator
+from airflow.contrib.sensors.gcp_bigtable_sensor import \
+    BigtableTableWaitForReplicationSensor
 
 try:
     # noinspection PyProtectedMember


### PR DESCRIPTION
All sensors should be in the sensor package. However, I found one incorrect one that concerns GCP and I moved it to the right place. However, I am waiting for information about what to do with it. Should I publish it now or in the future?