### PR TITLE
[AIRFLOW-XXX] Use context manager to manage session

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -603,13 +603,12 @@ def next_execution(args):
 
 @cli_utils.action_logging
 def rotate_fernet_key(args):
-    session = settings.Session()
-    for conn in session.query(Connection).filter(
-            Connection.is_encrypted | Connection.is_extra_encrypted):
-        conn.rotate_fernet_key()
-    for var in session.query(Variable).filter(Variable.is_encrypted):
-        var.rotate_fernet_key()
-    session.commit()
+    with db.create_session() as session:
+        for conn in session.query(Connection).filter(
+                Connection.is_encrypted | Connection.is_extra_encrypted):
+            conn.rotate_fernet_key()
+        for var in session.query(Variable).filter(Variable.is_encrypted):
+            var.rotate_fernet_key()
 
 
 @cli_utils.action_logging


### PR DESCRIPTION
This is a minor problem that I have noticed. It does not apply to the GCP operator, so I should probably publish it from a private account.