### PR TITLE
[AIRFLOW-XXX] Add backreference

### DIFF
--- a/airflow/contrib/operators/gcp_bigtable_operator.py
+++ b/airflow/contrib/operators/gcp_bigtable_operator.py
@@ -51,6 +51,10 @@ class BigtableInstanceCreateOperator(BaseOperator, BigtableValidationMixin):
     For more details about instance creation have a look at the reference:
     https://googleapis.github.io/google-cloud-python/latest/bigtable/instance.html#google.cloud.bigtable.instance.Instance.create
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BigtableInstanceCreateOperator`
+
     :type instance_id: str
     :param instance_id: The ID of the Cloud Bigtable instance to create.
     :type main_cluster_id: str
@@ -157,6 +161,10 @@ class BigtableInstanceDeleteOperator(BaseOperator, BigtableValidationMixin):
     For more details about deleting instance have a look at the reference:
     https://googleapis.github.io/google-cloud-python/latest/bigtable/instance.html#google.cloud.bigtable.instance.Instance.delete
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BigtableInstanceDeleteOperator`
+
     :type instance_id: str
     :param instance_id: The ID of the Cloud Bigtable instance to delete.
     :param project_id: Optional, the ID of the GCP project.  If set to None or missing,
@@ -198,6 +206,10 @@ class BigtableTableCreateOperator(BaseOperator, BigtableValidationMixin):
 
     For more details about creating table have a look at the reference:
     https://googleapis.github.io/google-cloud-python/latest/bigtable/table.html#google.cloud.bigtable.table.Table.create
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BigtableTableCreateOperator`
 
     :type instance_id: str
     :param instance_id: The ID of the Cloud Bigtable instance that will
@@ -290,6 +302,10 @@ class BigtableTableDeleteOperator(BaseOperator, BigtableValidationMixin):
     For more details about deleting table have a look at the reference:
     https://googleapis.github.io/google-cloud-python/latest/bigtable/table.html#google.cloud.bigtable.table.Table.delete
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BigtableTableDeleteOperator`
+
     :type instance_id: str
     :param instance_id: The ID of the Cloud Bigtable instance.
     :type table_id: str
@@ -348,6 +364,10 @@ class BigtableClusterUpdateOperator(BaseOperator, BigtableValidationMixin):
     have a look at the reference:
     https://googleapis.github.io/google-cloud-python/latest/bigtable/cluster.html#google.cloud.bigtable.cluster.Cluster.update
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BigtableClusterUpdateOperator`
+
     :type instance_id: str
     :param instance_id: The ID of the Cloud Bigtable instance.
     :type cluster_id: str
@@ -404,6 +424,10 @@ class BigtableTableWaitForReplicationSensor(BaseSensorOperator, BigtableValidati
 
     For more details about cluster states for a table, have a look at the reference:
     https://googleapis.github.io/google-cloud-python/latest/bigtable/table.html#google.cloud.bigtable.table.Table.get_cluster_states
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BigtableTableWaitForReplicationSensor`
 
     :type instance_id: str
     :param instance_id: The ID of the Cloud Bigtable instance.

--- a/airflow/contrib/operators/gcp_compute_operator.py
+++ b/airflow/contrib/operators/gcp_compute_operator.py
@@ -67,6 +67,10 @@ class GceInstanceStartOperator(GceBaseOperator):
     """
     Starts an instance in Google Compute Engine.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:GceInstanceStartOperator`
+
     :param zone: Google Cloud Platform zone where the instance exists.
     :type zone: str
     :param resource_id: Name of the Compute Engine instance resource.
@@ -109,6 +113,10 @@ class GceInstanceStartOperator(GceBaseOperator):
 class GceInstanceStopOperator(GceBaseOperator):
     """
     Stops an instance in Google Compute Engine.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:GceInstanceStopOperator`
 
     :param zone: Google Cloud Platform zone where the instance exists.
     :type zone: str
@@ -158,6 +166,10 @@ class GceSetMachineTypeOperator(GceBaseOperator):
     """
     Changes the machine type for a stopped instance to the machine type specified in
         the request.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:GceSetMachineTypeOperator`
 
     :param zone: Google Cloud Platform zone where the instance exists.
     :type zone: str
@@ -267,6 +279,10 @@ class GceInstanceTemplateCopyOperator(GceBaseOperator):
     """
     Copies the instance template, applying specified changes.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:GceInstanceTemplateCopyOperator`
+
     :param resource_id: Name of the Instance Template
     :type resource_id: str
     :param body_patch: Patch to the body of instanceTemplates object following rfc7386
@@ -370,6 +386,10 @@ class GceInstanceGroupManagerUpdateTemplateOperator(GceBaseOperator):
     Patches the Instance Group Manager, replacing source template URL with the
     destination one. API V1 does not have update/patch operations for Instance
     Group Manager, so you must use beta or newer API version. Beta is the default.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:GceInstanceGroupManagerUpdateTemplateOperator`
 
     :param resource_id: Name of the Instance Group Manager
     :type resource_id: str

--- a/airflow/contrib/operators/gcp_function_operator.py
+++ b/airflow/contrib/operators/gcp_function_operator.py
@@ -83,6 +83,10 @@ class GcfFunctionDeployOperator(BaseOperator):
     Creates a function in Google Cloud Functions.
     If a function with this name already exists, it will be updated.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:GcfFunctionDeployOperator`
+
     :param location: Google Cloud Platform region where the function should be created.
     :type location: str
     :param body: Body of the Cloud Functions definition. The body must be a
@@ -273,6 +277,10 @@ FUNCTION_NAME_COMPILED_PATTERN = re.compile(FUNCTION_NAME_PATTERN)
 class GcfFunctionDeleteOperator(BaseOperator):
     """
     Deletes the specified function from Google Cloud Functions.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:GcfFunctionDeleteOperator`
 
     :param name: A fully-qualified function name, matching
         the pattern: `^projects/[^/]+/locations/[^/]+/functions/[^/]+$`

--- a/airflow/contrib/operators/gcp_spanner_operator.py
+++ b/airflow/contrib/operators/gcp_spanner_operator.py
@@ -98,6 +98,10 @@ class CloudSpannerInstanceDeleteOperator(BaseOperator):
     Deletes a Cloud Spanner instance. If an instance does not exist,
     no action is taken and the operator succeeds.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudSpannerInstanceDeleteOperator`
+
     :param instance_id: The Cloud Spanner instance ID.
     :type instance_id: str
     :param project_id: Optional, the ID of the project that owns the Cloud Spanner
@@ -143,6 +147,10 @@ class CloudSpannerInstanceDeleteOperator(BaseOperator):
 class CloudSpannerInstanceDatabaseQueryOperator(BaseOperator):
     """
     Executes an arbitrary DML query (INSERT, UPDATE, DELETE).
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudSpannerInstanceDatabaseQueryOperator`
 
     :param instance_id: The Cloud Spanner instance ID.
     :type instance_id: str
@@ -216,6 +224,10 @@ class CloudSpannerInstanceDatabaseDeployOperator(BaseOperator):
     Creates a new Cloud Spanner database, or if database exists,
     the operator does nothing.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudSpannerInstanceDatabaseDeployOperator`
+
     :param instance_id: The Cloud Spanner instance ID.
     :type instance_id: str
     :param database_id: The Cloud Spanner database ID.
@@ -282,6 +294,10 @@ class CloudSpannerInstanceDatabaseDeployOperator(BaseOperator):
 class CloudSpannerInstanceDatabaseUpdateOperator(BaseOperator):
     """
     Updates a Cloud Spanner database with the specified DDL statement.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudSpannerInstanceDatabaseUpdateOperator`
 
     :param instance_id: The Cloud Spanner instance ID.
     :type instance_id: str
@@ -356,6 +372,10 @@ class CloudSpannerInstanceDatabaseUpdateOperator(BaseOperator):
 class CloudSpannerInstanceDatabaseDeleteOperator(BaseOperator):
     """
     Deletes a Cloud Spanner database.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudSpannerInstanceDatabaseDeleteOperator`
 
     :param instance_id: Cloud Spanner instance ID.
     :type instance_id: str

--- a/airflow/contrib/operators/gcp_sql_operator.py
+++ b/airflow/contrib/operators/gcp_sql_operator.py
@@ -205,6 +205,10 @@ class CloudSqlInstanceCreateOperator(CloudSqlBaseOperator):
     If an instance with the same name exists, no action will be taken and
     the operator will succeed.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudSqlInstanceCreateOperator`
+
     :param body: Body required by the Cloud SQL insert API, as described in
         https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances/insert
         #request-body
@@ -278,6 +282,10 @@ class CloudSqlInstancePatchOperator(CloudSqlBaseOperator):
     to the rules of patch semantics.
     https://cloud.google.com/sql/docs/mysql/admin-api/how-tos/performance#patch
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudSqlInstancePatchOperator`
+
     :param body: Body required by the Cloud SQL patch API, as described in
         https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances/patch#request-body
     :type body: dict
@@ -329,6 +337,10 @@ class CloudSqlInstanceDeleteOperator(CloudSqlBaseOperator):
     """
     Deletes a Cloud SQL instance.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudSqlInstanceDeleteOperator`
+
     :param instance: Cloud SQL instance ID. This does not include the project ID.
     :type instance: str
     :param project_id: Optional, Google Cloud Platform Project ID. If set to None or missing,
@@ -368,6 +380,10 @@ class CloudSqlInstanceDeleteOperator(CloudSqlBaseOperator):
 class CloudSqlInstanceDatabaseCreateOperator(CloudSqlBaseOperator):
     """
     Creates a new database inside a Cloud SQL instance.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudSqlInstanceDatabaseCreateOperator`
 
     :param instance: Database instance ID. This does not include the project ID.
     :type instance: str
@@ -438,6 +454,10 @@ class CloudSqlInstanceDatabasePatchOperator(CloudSqlBaseOperator):
     instance using patch semantics.
     See: https://cloud.google.com/sql/docs/mysql/admin-api/how-tos/performance#patch
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudSqlInstanceDatabasePatchOperator`
+
     :param instance: Database instance ID. This does not include the project ID.
     :type instance: str
     :param database: Name of the database to be updated in the instance.
@@ -507,6 +527,10 @@ class CloudSqlInstanceDatabaseDeleteOperator(CloudSqlBaseOperator):
     """
     Deletes a database from a Cloud SQL instance.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudSqlInstanceDatabaseDeleteOperator`
+
     :param instance: Database instance ID. This does not include the project ID.
     :type instance: str
     :param database: Name of the database to be deleted in the instance.
@@ -562,6 +586,10 @@ class CloudSqlInstanceExportOperator(CloudSqlBaseOperator):
 
     Note: This operator is idempotent. If executed multiple times with the same
     export file URI, the export file in GCS will simply be overridden.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudSqlInstanceImportOperator`
 
     :param instance: Cloud SQL instance ID. This does not include the project ID.
     :type instance: str
@@ -635,6 +663,10 @@ class CloudSqlInstanceImportOperator(CloudSqlBaseOperator):
     If the import file was generated in a different way, idempotence is not guaranteed.
     It has to be ensured on the SQL file level.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudSqlInstanceImportOperator`
+
     :param instance: Cloud SQL instance ID. This does not include the project ID.
     :type instance: str
     :param body: The request body, as described in
@@ -691,6 +723,10 @@ class CloudSqlQueryOperator(BaseOperator):
     """
     Performs DML or DDL query on an existing Cloud Sql instance. It optionally uses
     cloud-sql-proxy to establish secure connection with the database.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudSqlQueryOperator`
 
     :param sql: SQL query or list of queries to run (should be DML or DDL query -
         this operator does not return any data from the database,

--- a/airflow/contrib/operators/gcs_acl_operator.py
+++ b/airflow/contrib/operators/gcs_acl_operator.py
@@ -26,6 +26,10 @@ class GoogleCloudStorageBucketCreateAclEntryOperator(BaseOperator):
     """
     Creates a new ACL entry on the specified bucket.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:GoogleCloudStorageBucketCreateAclEntryOperator`
+
     :param bucket: Name of a bucket.
     :type bucket: str
     :param entity: The entity holding the permission, in one of the following forms:
@@ -68,6 +72,10 @@ class GoogleCloudStorageBucketCreateAclEntryOperator(BaseOperator):
 class GoogleCloudStorageObjectCreateAclEntryOperator(BaseOperator):
     """
     Creates a new ACL entry on the specified object.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:GoogleCloudStorageObjectCreateAclEntryOperator`
 
     :param bucket: Name of a bucket.
     :type bucket: str

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -34,6 +34,10 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
     point the operator to a Google cloud storage object name. The object in
     Google cloud storage must be a JSON file with the schema fields in it.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:GoogleCloudStorageToBigQueryOperator`
+
     :param bucket: The bucket to load from. (templated)
     :type bucket: str
     :param source_objects: List of Google cloud storage URIs to load from. (templated)

--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -35,6 +35,10 @@ class BashOperator(BaseOperator):
     """
     Execute a Bash script, command or set of commands.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BashOperator`
+
     :param bash_command: The command, set of commands or reference to a
         bash script (must be '.sh') to be executed. (templated)
     :type bash_command: str

--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -39,6 +39,10 @@ class PythonOperator(BaseOperator):
     """
     Executes a Python callable
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:PythonOperator`
+
     :param python_callable: A reference to an object that is callable
     :type python_callable: python callable
     :param op_kwargs: a dictionary of keyword arguments that will get unpacked

--- a/docs/howto/operator.rst
+++ b/docs/howto/operator.rst
@@ -27,6 +27,8 @@ information.
 
 .. contents:: :local:
 
+.. _howto/operator:BashOperator:
+
 BashOperator
 ------------
 
@@ -71,6 +73,8 @@ template to it, which will fail.
         bash_command="/home/batcher/test.sh ",
         dag=dag)
 
+.. _howto/operator:PythonOperator:
+
 PythonOperator
 --------------
 
@@ -106,6 +110,8 @@ is evaluated as a :ref:`Jinja template <jinja-templating>`.
 Google Cloud Storage Operators
 ------------------------------
 
+.. _howto/operator:GoogleCloudStorageToBigQueryOperator:
+
 GoogleCloudStorageToBigQueryOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -122,6 +128,8 @@ to execute a BigQuery load job.
 
 Google Compute Engine Operators
 -------------------------------
+
+.. _howto/operator:GceInstanceStartOperator:
 
 GceInstanceStartOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -177,6 +185,7 @@ More information
 See `Google Compute Engine API documentation for start
 <https://cloud.google.com/compute/docs/reference/rest/v1/instances/start>`_.
 
+.. _howto/operator:GceInstanceStopOperator:
 
 GceInstanceStopOperator
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -231,6 +240,7 @@ More information
 See `Google Compute Engine API documentation for stop
 <https://cloud.google.com/compute/docs/reference/rest/v1/instances/stop>`_.
 
+.. _howto/operator:GceSetMachineTypeOperator:
 
 GceSetMachineTypeOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -291,6 +301,7 @@ More information
 See `Google Compute Engine API documentation for setMachineType
 <https://cloud.google.com/compute/docs/reference/rest/v1/instances/setMachineType>`_.
 
+.. _howto/operator:GceInstanceTemplateCopyOperator:
 
 GceInstanceTemplateCopyOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -350,6 +361,8 @@ More information
 
 See `Google Compute Engine API documentation for instanceTemplates
 <https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates>`_.
+
+.. _howto/operator:GceInstanceGroupManagerUpdateTemplateOperator:
 
 GceInstanceGroupManagerUpdateTemplateOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -431,6 +444,7 @@ All examples below rely on the following variables, which can be passed via envi
     :start-after: [START howto_operator_gcp_bigtable_args]
     :end-before: [END howto_operator_gcp_bigtable_args]
 
+.. _howto/operator:BigtableInstanceCreateOperator:
 
 BigtableInstanceCreateOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -453,6 +467,8 @@ it will be retrieved from the GCP connection used. Both variants are shown:
     :start-after: [START howto_operator_gcp_bigtable_instance_create]
     :end-before: [END howto_operator_gcp_bigtable_instance_create]
 
+.. _howto/operator:BigtableInstanceDeleteOperator:
+
 BigtableInstanceDeleteOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -471,6 +487,8 @@ it will be retrieved from the GCP connection used. Both variants are shown:
     :start-after: [START howto_operator_gcp_bigtable_instance_delete]
     :end-before: [END howto_operator_gcp_bigtable_instance_delete]
 
+.. _howto/operator:BigtableClusterUpdateOperator:
+
 BigtableClusterUpdateOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -488,6 +506,8 @@ it will be retrieved from the GCP connection used. Both variants are shown:
     :dedent: 4
     :start-after: [START howto_operator_gcp_bigtable_cluster_update]
     :end-before: [END howto_operator_gcp_bigtable_cluster_update]
+
+.. _howto/operator:BigtableTableCreateOperator:
 
 BigtableTableCreateOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -519,6 +539,7 @@ Please refer to the Python Client for Google Cloud Bigtable documentation
 `for Table <https://googleapis.github.io/google-cloud-python/latest/bigtable/table.html>`_ and `for Column
 Families <https://googleapis.github.io/google-cloud-python/latest/bigtable/column-family.html>`_.
 
+.. _howto/operator:BigtableTableDeleteOperator:
 
 BigtableTableDeleteOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -537,6 +558,8 @@ it will be retrieved from the GCP connection used. Both variants are shown:
     :dedent: 4
     :start-after: [START howto_operator_gcp_bigtable_table_delete]
     :end-before: [END howto_operator_gcp_bigtable_table_delete]
+
+.. _howto/operator:BigtableTableWaitForReplicationSensor:
 
 BigtableTableWaitForReplicationSensor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -563,6 +586,8 @@ Using the operator
 
 Google Cloud Functions Operators
 --------------------------------
+
+.. _howto/operator:GcfFunctionDeleteOperator:
 
 GcfFunctionDeleteOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -606,6 +631,8 @@ More information
 
 See `Google Cloud Functions API documentation for delete
 <https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions/delete>`_.
+
+.. _howto/operator:GcfFunctionDeployOperator:
 
 GcfFunctionDeployOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -742,6 +769,8 @@ See `Google Cloud Functions API documentation for create
 Google Cloud Spanner Operators
 ------------------------------
 
+.. _howto/operator:CloudSpannerInstanceDatabaseDeleteOperator:
+
 CloudSpannerInstanceDatabaseDeleteOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -788,6 +817,7 @@ More information
 See `Google Cloud Spanner API documentation for database drop call
 <https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances.databases/dropDatabase>`_.
 
+.. _howto/operator:CloudSpannerInstanceDatabaseDeployOperator:
 
 CloudSpannerInstanceDatabaseDeployOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -836,6 +866,8 @@ More information
 
 See Google Cloud Spanner API documentation for `database create
 <https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances.databases/create>`_
+
+.. _howto/operator:CloudSpannerInstanceDatabaseUpdateOperator:
 
 CloudSpannerInstanceDatabaseUpdateOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -895,6 +927,8 @@ More information
 See Google Cloud Spanner API documentation for `database update_ddl
 <https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances.databases/updateDdl>`_.
 
+.. _howto/operator:CloudSpannerInstanceDatabaseQueryOperator:
+
 CloudSpannerInstanceDatabaseQueryOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -939,6 +973,8 @@ More information
 
 See Google Cloud Spanner API documentation for `the DML syntax
 <https://cloud.google.com/spanner/docs/dml-syntax>`_.
+
+.. _howto/operator:CloudSpannerInstanceDeleteOperator:
 
 CloudSpannerInstanceDeleteOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -988,6 +1024,8 @@ See `Google Cloud Spanner API documentation for instance delete
 
 Google Cloud Sql Operators
 --------------------------
+
+.. _howto/operator:CloudSqlInstanceDatabaseCreateOperator:
 
 CloudSqlInstanceDatabaseCreateOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1041,6 +1079,8 @@ More information
 See `Google Cloud SQL API documentation for database insert
 <https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/databases/insert>`_.
 
+.. _howto/operator:CloudSqlInstanceDatabaseDeleteOperator:
+
 CloudSqlInstanceDatabaseDeleteOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -1085,6 +1125,8 @@ More information
 
 See `Google Cloud SQL API documentation for database delete
 <https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/databases/delete>`_.
+
+.. _howto/operator:CloudSqlInstanceDatabasePatchOperator:
 
 CloudSqlInstanceDatabasePatchOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1140,6 +1182,8 @@ More information
 See `Google Cloud SQL API documentation for database patch
 <https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/databases/patch>`_.
 
+.. _howto/operator:CloudSqlInstanceDeleteOperator:
+
 CloudSqlInstanceDeleteOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -1185,7 +1229,7 @@ More information
 See `Google Cloud SQL API documentation for delete
 <https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances/delete>`_.
 
-.. CloudSqlInstanceExportOperator:
+.. _howto/operator:CloudSqlInstanceExportOperator:
 
 CloudSqlInstanceExportOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1269,7 +1313,7 @@ as shown in the example:
     :end-before: [END howto_operator_cloudsql_export_gcs_permissions]
 
 
-.. CloudSqlInstanceImportOperator:
+.. _howto/operator:CloudSqlInstanceImportOperator:
 
 CloudSqlInstanceImportOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1364,6 +1408,8 @@ as shown in the example:
     :start-after: [START howto_operator_cloudsql_import_gcs_permissions]
     :end-before: [END howto_operator_cloudsql_import_gcs_permissions]
 
+.. _howto/operator:CloudSqlInstanceCreateOperator:
+
 CloudSqlInstanceCreateOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -1418,6 +1464,8 @@ More information
 
 See `Google Cloud SQL API documentation for insert
 <https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances/insert>`_.
+
+.. _howto/operator:CloudSqlInstancePatchOperator:
 
 CloudSqlInstancePatchOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1475,6 +1523,7 @@ More information
 See `Google Cloud SQL API documentation for patch
 <https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances/patch>`_.
 
+.. _howto/operator:CloudSqlQueryOperator:
 
 CloudSqlQueryOperator
 ^^^^^^^^^^^^^^^^^^^^^
@@ -1569,6 +1618,8 @@ See `Google Cloud SQL Proxy documentation
 Google Cloud Storage Operators
 ------------------------------
 
+.. _howto/operator:GoogleCloudStorageBucketCreateAclEntryOperator:
+
 GoogleCloudStorageBucketCreateAclEntryOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -1610,6 +1661,8 @@ More information
 
 See `Google Cloud Storage BucketAccessControls insert documentation
 <https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls/insert>`_.
+
+.. _howto/operator:GoogleCloudStorageObjectCreateAclEntryOperator:
 
 GoogleCloudStorageObjectCreateAclEntryOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
My goal is to have the operators information only in two places - in the `howto / operator.rst` file and in the class's documentation. This PRs simplifies navigation between these two places.

Preview: http://general-chairs.surge.sh/howto/operator.html#