### PR TITLE
[3/3] Docs changes - Refactor Base GCP Hook

### DIFF
--- a/airflow/contrib/hooks/gcp_bigtable_hook.py
+++ b/airflow/contrib/hooks/gcp_bigtable_hook.py
@@ -22,7 +22,7 @@ from google.cloud.bigtable.cluster import Cluster
 from google.cloud.bigtable.instance import Instance
 from google.cloud.bigtable.table import Table
 from google.cloud.bigtable_admin_v2 import enums
-from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook, fallback_to_default_project_id
 
 
 class BigtableHook(GoogleCloudBaseHook):
@@ -46,7 +46,7 @@ class BigtableHook(GoogleCloudBaseHook):
                                   admin=True)
         return self._client
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def get_instance(self, instance_id, project_id=None):
         """
         Retrieves and returns the specified Cloud Bigtable instance if it exists.
@@ -65,7 +65,7 @@ class BigtableHook(GoogleCloudBaseHook):
             return None
         return instance
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def delete_instance(self, instance_id, project_id=None):
         """
         Deletes the specified Cloud Bigtable instance.
@@ -86,7 +86,7 @@ class BigtableHook(GoogleCloudBaseHook):
             self.log.info("The instance '%s' does not exist in project '%s'. Exiting", instance_id,
                           project_id)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def create_instance(self,
                         instance_id,
                         main_cluster_id,
@@ -195,7 +195,7 @@ class BigtableHook(GoogleCloudBaseHook):
         table = Table(table_id, instance)
         table.create(initial_split_keys, column_families)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def delete_table(self, instance_id, table_id, project_id=None):
         """
         Deletes the specified table in Cloud Bigtable.

--- a/airflow/contrib/hooks/gcp_compute_hook.py
+++ b/airflow/contrib/hooks/gcp_compute_hook.py
@@ -21,7 +21,7 @@ import time
 from googleapiclient.discovery import build
 
 from airflow import AirflowException
-from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook, fallback_to_default_project_id
 
 # Number of retries - used by googleapiclient method calls to perform retries
 # For requests that are "retriable"
@@ -68,7 +68,7 @@ class GceHook(GoogleCloudBaseHook):
                                http=http_authorized, cache_discovery=False)
         return self._conn
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def start_instance(self, zone, resource_id, project_id=None):
         """
         Starts an existing instance defined by project_id, zone and resource_id.
@@ -99,7 +99,7 @@ class GceHook(GoogleCloudBaseHook):
                                              operation_name=operation_name,
                                              zone=zone)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def stop_instance(self, zone, resource_id, project_id=None):
         """
         Stops an instance defined by project_id, zone and resource_id
@@ -130,7 +130,7 @@ class GceHook(GoogleCloudBaseHook):
                                              operation_name=operation_name,
                                              zone=zone)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def set_machine_type(self, zone, resource_id, body, project_id=None):
         """
         Sets machine type of an instance defined by project_id, zone and resource_id.
@@ -166,7 +166,7 @@ class GceHook(GoogleCloudBaseHook):
             project=project_id, zone=zone, instance=resource_id, body=body)\
             .execute(num_retries=NUM_RETRIES)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def get_instance_template(self, resource_id, project_id=None):
         """
         Retrieves instance template by project_id and resource_id.
@@ -188,7 +188,7 @@ class GceHook(GoogleCloudBaseHook):
         ).execute(num_retries=NUM_RETRIES)
         return response
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def insert_instance_template(self, body, request_id=None, project_id=None):
         """
         Inserts instance template using body specified
@@ -222,7 +222,7 @@ class GceHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def get_instance_group_manager(self, zone, resource_id, project_id=None):
         """
         Retrieves Instance Group Manager by project_id, zone and resource_id.
@@ -247,7 +247,7 @@ class GceHook(GoogleCloudBaseHook):
         ).execute(num_retries=NUM_RETRIES)
         return response
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def patch_instance_group_manager(self, zone, resource_id,
                                      body, request_id=None, project_id=None):
         """

--- a/airflow/contrib/hooks/gcp_dataflow_hook.py
+++ b/airflow/contrib/hooks/gcp_dataflow_hook.py
@@ -25,7 +25,7 @@ import uuid
 
 from googleapiclient.discovery import build
 
-from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook, provide_gcp_credential_file
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 # This is the default location
@@ -190,7 +190,7 @@ class DataFlowHook(GoogleCloudBaseHook):
         return build(
             'dataflow', 'v1b3', http=http_authorized, cache_discovery=False)
 
-    @GoogleCloudBaseHook._Decorators.provide_gcp_credential_file
+    @provide_gcp_credential_file
     def _start_dataflow(self, variables, name, command_prefix, label_formatter):
         variables = self._set_variables(variables)
         cmd = command_prefix + self._build_cmd(variables, label_formatter)

--- a/airflow/contrib/hooks/gcp_function_hook.py
+++ b/airflow/contrib/hooks/gcp_function_hook.py
@@ -22,7 +22,7 @@ import requests
 from googleapiclient.discovery import build
 
 from airflow import AirflowException
-from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook, fallback_to_default_project_id
 
 # Number of retries - used by googleapiclient method calls to perform retries
 # For requests that are "retriable"
@@ -88,7 +88,7 @@ class GcfHook(GoogleCloudBaseHook):
         return self.get_conn().projects().locations().functions().get(
             name=name).execute(num_retries=NUM_RETRIES)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def create_new_function(self, location, body, project_id=None):
         """
         Creates a new function in Cloud Function in the location specified in the body.
@@ -129,7 +129,7 @@ class GcfHook(GoogleCloudBaseHook):
         operation_name = response["name"]
         self._wait_for_operation_to_complete(operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def upload_function_zip(self, location, zip_path, project_id=None):
         """
         Uploads zip file with sources.

--- a/airflow/contrib/hooks/gcp_spanner_hook.py
+++ b/airflow/contrib/hooks/gcp_spanner_hook.py
@@ -21,7 +21,7 @@ from google.cloud.spanner_v1.client import Client
 from google.longrunning.operations_grpc_pb2 import Operation  # noqa: F401
 
 from airflow import AirflowException
-from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook, fallback_to_default_project_id
 
 
 class CloudSpannerHook(GoogleCloudBaseHook):
@@ -51,7 +51,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
             self._client = Client(project=project_id, credentials=self._get_credentials())
         return self._client
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def get_instance(self, instance_id, project_id=None):
         """
         Gets information about a particular instance.
@@ -105,7 +105,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
             result = operation.result()
             self.log.info(result)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def create_instance(self, instance_id, configuration_name, node_count,
                         display_name, project_id=None):
         """
@@ -132,7 +132,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
         self._apply_to_instance(project_id, instance_id, configuration_name,
                                 node_count, display_name, lambda x: x.create())
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def update_instance(self, instance_id, configuration_name, node_count,
                         display_name, project_id=None):
         """
@@ -159,7 +159,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
         return self._apply_to_instance(project_id, instance_id, configuration_name,
                                        node_count, display_name, lambda x: x.update())
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def delete_instance(self, instance_id, project_id=None):
         """
         Deletes an existing Cloud Spanner instance.
@@ -180,7 +180,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
             self.log.error('An error occurred: %s. Exiting.', e.message)
             raise e
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def get_database(self, instance_id, database_id, project_id=None):
         """
         Retrieves a database in Cloud Spanner. If the database does not exist
@@ -208,7 +208,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
         else:
             return database
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def create_database(self, instance_id, database_id, ddl_statements, project_id=None):
         """
         Creates a new database in Cloud Spanner.
@@ -243,7 +243,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
             self.log.info(result)
         return
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def update_database(self, instance_id, database_id, ddl_statements,
                         project_id=None,
                         operation_id=None):
@@ -287,7 +287,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
             self.log.error('An error occurred: %s. Exiting.', e.message)
             raise e
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def delete_database(self, instance_id, database_id, project_id=None):
         """
         Drops a database in Cloud Spanner.
@@ -324,7 +324,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
             self.log.info(result)
         return
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def execute_dml(self, instance_id, database_id, queries, project_id=None):
         """
         Executes an arbitrary DML query (INSERT, UPDATE, DELETE).

--- a/airflow/contrib/hooks/gcp_sql_hook.py
+++ b/airflow/contrib/hooks/gcp_sql_hook.py
@@ -39,7 +39,7 @@ import requests
 from googleapiclient.discovery import build
 
 from airflow import AirflowException, LoggingMixin
-from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook, fallback_to_default_project_id
 
 # Number of retries - used by googleapiclient method calls to perform retries
 # For requests that are "retriable"
@@ -94,7 +94,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
                                http=http_authorized, cache_discovery=False)
         return self._conn
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def get_instance(self, instance, project_id=None):
         """
         Retrieves a resource containing information about a Cloud SQL instance.
@@ -112,7 +112,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
             instance=instance
         ).execute(num_retries=NUM_RETRIES)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def create_instance(self, body, project_id=None):
         """
         Creates a new Cloud SQL instance.
@@ -133,7 +133,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def patch_instance(self, body, instance, project_id=None):
         """
         Updates settings of a Cloud SQL instance.
@@ -160,7 +160,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def delete_instance(self, instance, project_id=None):
         """
         Deletes a Cloud SQL instance.
@@ -180,7 +180,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def get_database(self, instance, database, project_id=None):
         """
         Retrieves a database resource from a Cloud SQL instance.
@@ -202,7 +202,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
             database=database
         ).execute(num_retries=NUM_RETRIES)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def create_database(self, instance, body, project_id=None):
         """
         Creates a new database inside a Cloud SQL instance.
@@ -226,7 +226,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def patch_database(self, instance, database, body, project_id=None):
         """
         Updates a database resource inside a Cloud SQL instance.
@@ -256,7 +256,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def delete_database(self, instance, database, project_id=None):
         """
         Deletes a database from a Cloud SQL instance.
@@ -279,7 +279,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def export_instance(self, instance, body, project_id=None):
         """
         Exports data from a Cloud SQL instance to a Cloud Storage bucket as a SQL dump
@@ -310,7 +310,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
                 'Exporting instance {} failed: {}'.format(instance, ex.content)
             )
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def import_instance(self, instance, body, project_id=None):
         """
         Imports data into a Cloud SQL instance from a SQL dump or CSV file in

--- a/airflow/contrib/hooks/gcp_vision_hook.py
+++ b/airflow/contrib/hooks/gcp_vision_hook.py
@@ -23,7 +23,7 @@ from google.cloud.vision_v1 import ProductSearchClient
 from google.protobuf.json_format import MessageToDict
 
 from airflow import AirflowException
-from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook, fallback_to_default_project_id
 
 
 class NameDeterminer:
@@ -109,7 +109,7 @@ class CloudVisionHook(GoogleCloudBaseHook):
             self._client = ProductSearchClient(credentials=self._get_credentials())
         return self._client
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def create_product_set(
         self,
         location,
@@ -146,7 +146,7 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         return product_set_id
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def get_product_set(
         self, location, product_set_id, project_id=None, retry=None, timeout=None, metadata=None
     ):
@@ -168,7 +168,7 @@ class CloudVisionHook(GoogleCloudBaseHook):
         self.log.debug('ProductSet retrieved:\n%s', response)
         return MessageToDict(response)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def update_product_set(
         self,
         product_set,
@@ -201,7 +201,7 @@ class CloudVisionHook(GoogleCloudBaseHook):
         self.log.debug('ProductSet updated:\n%s', response)
         return MessageToDict(response)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def delete_product_set(
         self, location, product_set_id, project_id=None, retry=None, timeout=None, metadata=None
     ):
@@ -222,7 +222,7 @@ class CloudVisionHook(GoogleCloudBaseHook):
         self.log.info('ProductSet with the name [%s] deleted.', name)
         return response
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def create_product(
         self, location, product, project_id=None, product_id=None, retry=None, timeout=None, metadata=None
     ):
@@ -252,7 +252,7 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         return product_id
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def get_product(self, location, product_id, project_id=None, retry=None, timeout=None, metadata=None):
         """
         For the documentation see:
@@ -272,7 +272,7 @@ class CloudVisionHook(GoogleCloudBaseHook):
         self.log.debug('Product retrieved:\n%s', response)
         return MessageToDict(response)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def update_product(
         self,
         product,
@@ -303,7 +303,7 @@ class CloudVisionHook(GoogleCloudBaseHook):
         self.log.debug('Product updated:\n%s', response)
         return MessageToDict(response)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def delete_product(self, location, product_id, project_id=None, retry=None, timeout=None, metadata=None):
         """
         For the documentation see:

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -2934,7 +2934,9 @@ class DAG(BaseDag, LoggingMixin):
         new active DAG runs
     :type max_active_runs: int
     :param dagrun_timeout: specify how long a DagRun should be up before
-        timing out / failing, so that new DagRuns can be created
+        timing out / failing, so that new DagRuns can be created. The timeout
+        is only enforced for scheduled DagRuns, and only once the
+        # of active DagRuns == max_active_runs.
     :type dagrun_timeout: datetime.timedelta
     :param sla_miss_callback: specify a function to call when reporting SLA
         timeouts.

--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -21,7 +21,7 @@ import gzip
 import functools
 import pendulum
 from io import BytesIO as IO
-from flask import after_this_request, redirect, request, url_for, g
+from flask import after_this_request, flash, redirect, request, url_for, g
 from airflow.models.log import Log
 from airflow.utils.db import create_session
 
@@ -120,6 +120,7 @@ def has_dag_access(**dag_kwargs):
                                                                    dag_id)))):
                 return f(self, *args, **kwargs)
             else:
+                flash("Access is Denied", "danger")
                 return redirect(url_for(self.appbuilder.sm.auth_view.
                                         __class__.__name__ + ".login"))
         return wrapper

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -267,9 +267,9 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         :param permission: permission on dag_id(e.g can_read, can_edit).
         :type permission: str
         :param view_name: name of view-menu(e.g dag id is a view-menu as well).
-        :type permission: str
+        :type view_name: str
         :param user: user name
-        :type permission: str
+        :type user: str
         :return: a bool whether user could perform certain permission on the dag_id.
         :rtype bool
         """

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -443,11 +443,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         pvms = [p for p in pvms if p.permission and p.view_menu]
 
         admin = self.find_role('Admin')
-        existing_perms_vms = set(admin.permissions)
-        for p in pvms:
-            if p not in existing_perms_vms:
-                existing_perms_vms.add(p)
-        admin.permissions = list(existing_perms_vms)
+        admin.permissions = list(set(admin.permissions) | set(pvms))
 
         self.get_session.commit()
 

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -109,9 +109,9 @@
       </li>
       <li>
         <a href="{{ url_for('Airflow.delete', dag_id=dag.dag_id) }}"
-        onclick="return confirmDeleteDag('{{ dag.safe_dag_id }}')">
-        <span class="glyphicon glyphicon-remove-circle" style="color:red" aria-hidden="true"></span>
-        Delete
+          onclick="return confirmDeleteDag('{{ dag.safe_dag_id }}')">
+          <span class="glyphicon glyphicon-remove-circle" style="color:red" aria-hidden="true"></span>
+          Delete
         </a>
       </li>
     </ul>
@@ -135,23 +135,23 @@
         </div>
         <div class="modal-body">
           <div id="div_btn_subdag">
-              <button id="btn_subdag" type="button" class="btn btn-primary">
+            <a id="btn_subdag" type="button" class="btn btn-primary" data-base-url="{{ url_for('Airflow.' + dag.get_default_view()) }}">
                 Zoom into Sub DAG
-              </button>
+              </a>
               <hr/>
           </div>
-          <button id="btn_task" type="button" class="btn btn-primary">
+          <a id="btn_task" type="button" class="btn btn-primary" data-base-url="{{ url_for('Airflow.task') }}">
             Task Instance Details
-          </button>
-          <button id="btn_rendered" type="button" class="btn btn-primary">
+          </a>
+          <a id="btn_rendered" type="button" class="btn btn-primary" data-base-url="{{ url_for('Airflow.rendered') }}">
             Rendered
-          </button>
-          <button id="btn_ti" type="button" class="btn btn-primary">
+          </a>
+          <a id="btn_ti" type="button" class="btn btn-primary" data-base-url="{{ url_for('TaskInstanceModelView.list') }}">
             Task Instances
-          </button>
-          <button id="btn_log" type="button" class="btn btn-primary">
+          </a>
+          <a id="btn_log" type="button" class="btn btn-primary" data-base-url="{{ url_for('Airflow.log') }}">
             View Log
-          </button>
+          </a>
           <hr/>
           <div>
             <label style="display:inline"> Download Log (by attempts): </label>
@@ -159,10 +159,10 @@
             </ul>
           </div>
           <hr/>
-          <button id="btn_run" type="button" class="btn btn-primary"
+          <a id="btn_run" type="button" class="btn btn-primary" data-base-url="{{ url_for('Airflow.run') }}"
             title="Runs a single task instance">
             Run
-          </button>
+          </a>
           <span class="btn-group">
             <button id="btn_ignore_all_deps"
               type="button" class="btn" data-toggle="button"
@@ -181,10 +181,10 @@
             >Ignore Task Deps</button>
           </span>
           <hr/>
-          <button id="btn_clear" type="button" class="btn btn-primary"
+          <a id="btn_clear" type="button" class="btn btn-primary" data-base-url="{{ url_for('Airflow.clear') }}"
               title="Clearing deletes the previous state of the task instance, allowing it to get re-triggered by the scheduler or a backfill command"
               >Clear
-          </button>
+          </a>
           <span class="btn-group">
             <button id="btn_past"
               type="button" class="btn" data-toggle="button"
@@ -210,9 +210,9 @@
             </button>
           </span>
           <hr/>
-          <button id="btn_failed" type="button" class="btn btn-primary">
+          <a id="btn_failed" type="button" class="btn btn-primary" data-base-url="{{ url_for('Airflow.failed') }}">
             Mark Failed
-          </button>
+          </a>
           <span class="btn-group">
             <button id="btn_failed_past"
               type="button" class="btn" data-toggle="button">Past</button>
@@ -228,9 +228,9 @@
             </button>
           </span>
           <hr/>
-          <button id="btn_success" type="button" class="btn btn-primary">
+          <a id="btn_success" type="button" class="btn btn-primary" data-base-url="{{ url_for('Airflow.success') }}">
             Mark Success
-          </button>
+          </a>
           <span class="btn-group">
             <button id="btn_success_past"
               type="button" class="btn" data-toggle="button">Past</button>
@@ -266,18 +266,18 @@
           </h4>
         </div>
         <div class="modal-body">
-          <button id="btn_edit_dagrun" type="button" class="btn btn-primary">
+          <a id="btn_edit_dagrun" type="button" class="btn btn-primary" href="{{ url_for('DagModelView.edit', pk=dag.dag_id) }}">
             Edit
-          </button>
-          <button id="btn_dagrun_clear" type="button" class="btn btn-primary">
+          </a>
+          <a id="btn_dagrun_clear" type="button" class="btn btn-primary" data-base-url="{{ url_for('Airflow.dagrun_clear') }}">
             Clear
-          </button>
-          <button id="btn_dagrun_failed" type="button" class="btn btn-primary">
+          </a>
+          <a id="btn_dagrun_failed" type="button" class="btn btn-primary" data-base-url="{{ url_for('Airflow.dagrun_failed') }}">
             Mark Failed
-          </button>
-          <button id="btn_dagrun_success" type="button" class="btn btn-primary">
+          </a>
+          <a id="btn_dagrun_success" type="button" class="btn btn-primary" data-base-url="{{ url_for('Airflow.dagrun_success') }}">
             Mark Success
-          </button>
+          </a>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">
@@ -315,6 +315,117 @@ function updateQueryStringParameter(uri, key, value) {
     var task_id = '';
     var exection_date = '';
     var subdag_id = '';
+
+    var buttons = Array.from(document.querySelectorAll('a[id^="btn_"][data-base-url]')).reduce(function(obj, elm) {
+      obj[elm.id.replace('btn_', '')] = elm;
+      return obj;
+    }, {});
+
+    // Update modal urls on toggle
+    document.addEventListener('click', function(event) {
+      if (event.target.matches('button[data-toggle="button"]')) {
+        updateModalUrls();
+      }
+    });
+
+    function updateButtonUrl(elm, params) {
+      elm.setAttribute('href', elm.dataset.baseUrl + '?' + $.param(params));
+    }
+
+    function updateModalUrls() {
+      updateButtonUrl(buttons.subdag, {
+        dag_id: dag_id,
+        execution_date: execution_date,
+      });
+
+      updateButtonUrl(buttons.task, {
+        dag_id: dag_id,
+        task_id: task_id,
+        execution_date: execution_date,
+      });
+
+      updateButtonUrl(buttons.rendered, {
+        dag_id: dag_id,
+        task_id: task_id,
+        execution_date: execution_date,
+      });
+
+      updateButtonUrl(buttons.ti, {
+        flt1_dag_id_equals: dag_id,
+        _flt_3_task_id: task_id,
+        _oc_TaskInstanceModelView: execution_date,
+      });
+
+      updateButtonUrl(buttons.log, {
+        dag_id: dag_id,
+        task_id: task_id,
+        execution_date: execution_date,
+      });
+
+      updateButtonUrl(buttons.run, {
+        dag_id: dag_id,
+        task_id: task_id,
+        execution_date: execution_date,
+        origin: window.url,
+        ignore_all_deps: document.querySelector('#btn_ignore_all_deps').classList.contains('active'),
+        ignore_task_deps: document.querySelector('#btn_ignore_task_deps').classList.contains('active'),
+        ignore_ti_state: document.querySelector('#btn_ignore_ti_state').classList.contains('active'),
+      });
+
+      updateButtonUrl(buttons.clear, {
+        dag_id: dag_id,
+        task_id: task_id,
+        execution_date: execution_date,
+        origin: window.url,
+        future: document.querySelector('#btn_future').classList.contains('active'),
+        past: document.querySelector('#btn_past').classList.contains('active'),
+        upstream: document.querySelector('#btn_upstream').classList.contains('active'),
+        downstream: document.querySelector('#btn_downstream').classList.contains('active'),
+        recursive: document.querySelector('#btn_upstream').classList.contains('active'),
+      });
+
+      updateButtonUrl(buttons.failed, {
+        dag_id: dag_id,
+        task_id: task_id,
+        execution_date: execution_date,
+        origin: window.url,
+        upstream: document.querySelector('#btn_failed_upstream').classList.contains('active'),
+        downstream: document.querySelector('#btn_failed_downstream').classList.contains('active'),
+        future: document.querySelector('#btn_failed_future').classList.contains('active'),
+        past: document.querySelector('#btn_failed_past').classList.contains('active'),
+      });
+
+      updateButtonUrl(buttons.success, {
+        dag_id: dag_id,
+        task_id: task_id,
+        execution_date: execution_date,
+        origin: window.url,
+        upstream: document.querySelector('#btn_success_upstream').classList.contains('active'),
+        downstream: document.querySelector('#btn_success_downstream').classList.contains('active'),
+        future: document.querySelector('#btn_success_future').classList.contains('active'),
+        past: document.querySelector('#btn_success_past').classList.contains('active'),
+      });
+
+      updateButtonUrl(buttons.dagrun_clear, {
+        dag_id: dag_id,
+        task_id: task_id,
+        execution_date: execution_date,
+        origin: window.url,
+      });
+
+      updateButtonUrl(buttons.dagrun_failed, {
+        dag_id: dag_id,
+        execution_date: execution_date,
+        origin: window.url,
+      });
+
+      updateButtonUrl(buttons.dagrun_success, {
+        dag_id: dag_id,
+        execution_date: execution_date,
+        origin: window.url,
+      });
+    }
+
     function call_modal(t, d, try_numbers, sd) {
       task_id = t;
       loc = String(window.location);
@@ -333,6 +444,8 @@ function updateQueryStringParameter(uri, key, value) {
           $("#div_btn_subdag").show();
           subdag_id = "{{ dag.dag_id }}."+t;
       }
+
+      updateModalUrls();
 
       $("#try_index > li").remove();
       var startIndex = (try_numbers > 2 ? 0 : 1)
@@ -377,138 +490,6 @@ function updateQueryStringParameter(uri, key, value) {
           This cannot be undone.");
     }
 
-    $("#btn_rendered").click(function(){
-      url = "{{ url_for('Airflow.rendered') }}" +
-        "?task_id=" + encodeURIComponent(task_id) +
-        "&dag_id=" + encodeURIComponent(dag_id) +
-        "&execution_date=" + encodeURIComponent(execution_date);
-      window.location = url;
-    });
-
-    $("#btn_subdag").click(function(){
-      url = "{{ url_for( 'Airflow.' + dag.get_default_view() ) }}" +
-        "?dag_id=" + encodeURIComponent(subdag_id) +
-        "&execution_date=" + encodeURIComponent(execution_date);
-      window.location = url;
-    });
-
-    $("#btn_log").click(function(){
-      url = "{{ url_for('Airflow.log') }}" +
-        "?task_id=" + encodeURIComponent(task_id) +
-        "&dag_id=" + encodeURIComponent(dag_id) +
-        "&execution_date=" + encodeURIComponent(execution_date);
-      window.location = url;
-    });
-
-    $("#btn_task").click(function(){
-      url = "{{ url_for('Airflow.task') }}" +
-        "?task_id=" + encodeURIComponent(task_id) +
-        "&dag_id=" + encodeURIComponent(dag_id) +
-        "&execution_date=" + encodeURIComponent(execution_date);
-      window.location = url;
-    });
-
-    $("#btn_ti").click(function(){
-      url = "{{ url_for('TaskInstanceModelView.list') }}" +
-        "?flt1_dag_id_equals=" + dag_id +
-        "&_flt_3_task_id=" + task_id +
-        "&_oc_TaskInstanceModelView=execution_date";
-      window.location = url;
-    });
-
-    $("#btn_run").click(function(){
-      url = "{{ url_for('Airflow.run') }}" +
-        "?task_id=" + encodeURIComponent(task_id) +
-        "&dag_id=" + encodeURIComponent(dag_id) +
-        "&ignore_all_deps=" + $('#btn_ignore_all_deps').hasClass('active') +
-        "&ignore_task_deps=" + $('#btn_ignore_task_deps').hasClass('active') +
-        "&ignore_ti_state=" + $('#btn_ignore_ti_state').hasClass('active') +
-        "&execution_date=" + encodeURIComponent(execution_date) +
-        "&origin=" + encodeURIComponent(window.location);
-      window.location = url;
-    });
-
-    $("#btn_clear").click(function(){
-      url = "{{ url_for('Airflow.clear') }}" +
-        "?task_id=" + encodeURIComponent(task_id) +
-        "&dag_id=" + encodeURIComponent(dag_id) +
-        "&future=" + $('#btn_future').hasClass('active') +
-        "&past=" + $('#btn_past').hasClass('active') +
-        "&upstream=" + $('#btn_upstream').hasClass('active') +
-        "&downstream=" + $('#btn_downstream').hasClass('active') +
-        "&recursive=" + $('#btn_recursive').hasClass('active') +
-        "&execution_date=" + encodeURIComponent(execution_date) +
-        "&origin=" + encodeURIComponent(window.location);
-      window.location = url;
-    });
-
-    $("#btn_dagrun_clear").click(function(){
-      url = "{{ url_for('Airflow.dagrun_clear') }}" +
-        "?task_id=" + encodeURIComponent(task_id) +
-        "&dag_id=" + encodeURIComponent(dag_id) +
-        "&execution_date=" + encodeURIComponent(execution_date) +
-        "&origin=" + encodeURIComponent(window.location);
-      window.location = url;
-    });
-
-    $("#btn_failed").click(function(){
-      url = "{{ url_for('Airflow.failed') }}" +
-        "?task_id=" + encodeURIComponent(task_id) +
-        "&dag_id=" + encodeURIComponent(dag_id) +
-        "&upstream=" + $('#btn_failed_upstream').hasClass('active') +
-        "&downstream=" + $('#btn_failed_downstream').hasClass('active') +
-        "&future=" + $('#btn_failed_future').hasClass('active') +
-        "&past=" + $('#btn_failed_past').hasClass('active') +
-        "&execution_date=" + encodeURIComponent(execution_date) +
-        "&origin=" + encodeURIComponent(window.location);
-
-      window.location = url;
-    });
-
-    $("#btn_success").click(function(){
-      url = "{{ url_for('Airflow.success') }}" +
-        "?task_id=" + encodeURIComponent(task_id) +
-        "&dag_id=" + encodeURIComponent(dag_id) +
-        "&upstream=" + $('#btn_success_upstream').hasClass('active') +
-        "&downstream=" + $('#btn_success_downstream').hasClass('active') +
-        "&future=" + $('#btn_success_future').hasClass('active') +
-        "&past=" + $('#btn_success_past').hasClass('active') +
-        "&execution_date=" + encodeURIComponent(execution_date) +
-        "&origin=" + encodeURIComponent(window.location);
-
-      window.location = url;
-    });
-
-    $('#btn_dagrun_failed').click(function(){
-      url = "{{ url_for('Airflow.dagrun_failed') }}" +
-        "?dag_id=" + encodeURIComponent(dag_id) +
-        "&execution_date=" + encodeURIComponent(execution_date) +
-        "&origin=" + encodeURIComponent(window.location);
-      window.location = url;
-    });
-
-    $('#btn_dagrun_success').click(function(){
-      url = "{{ url_for('Airflow.dagrun_success') }}" +
-        "?dag_id=" + encodeURIComponent(dag_id) +
-        "&execution_date=" + encodeURIComponent(execution_date) +
-        "&origin=" + encodeURIComponent(window.location);
-      window.location = url;
-    });
-
-    $("#btn_gantt").click(function(){
-      url = "{{ url_for('Airflow.gantt') }}" +
-        "?dag_id=" + encodeURIComponent(dag_id) +
-        "&execution_date=" + encodeURIComponent(execution_date);
-      window.location = url;
-    });
-
-    $("#btn_graph").click(function(){
-      url = "{{ url_for('Airflow.graph') }}" +
-        "?dag_id=" + encodeURIComponent(dag_id) +
-        "&execution_date=" + encodeURIComponent(execution_date);
-      window.location = url;
-    });
-
     $("#pause_resume").change(function() {
       var dag_id = $(this).attr('dag_id');
       if ($(this).prop('checked')) {
@@ -518,10 +499,6 @@ function updateQueryStringParameter(uri, key, value) {
       }
       url = "{{ url_for('Airflow.paused') }}" + '?is_paused=' + is_paused + '&dag_id=' + encodeURIComponent(dag_id);
       $.post(url);
-    });
-
-    $('#btn_edit_dagrun').click(function() {
-      window.location = "{{ url_for('DagModelView.edit', pk=dag.dag_id) }}";
     });
 
   </script>

--- a/tests/contrib/hooks/test_gcp_api_base_hook.py
+++ b/tests/contrib/hooks/test_gcp_api_base_hook.py
@@ -21,10 +21,12 @@
 import os
 import unittest
 
+from airflow import AirflowException
 from airflow.contrib.hooks import gcp_api_base_hook as hook
 
 import google.auth
 from google.auth.exceptions import GoogleAuthError
+
 try:
     from StringIO import StringIO
 except ImportError:
@@ -46,21 +48,102 @@ except GoogleAuthError:
     default_creds_available = False
 
 
+class provide_gcp_credential_file_TestCase(unittest.TestCase):
+    def setUp(self):
+        self.instance = hook.GoogleCloudBaseHook()
+
+    def test_provide_gcp_credential_file_decorator_key_path(self):
+        key_path = '/test/key-path'
+        self.instance.extras = {'extra__google_cloud_platform__key_path': key_path}
+
+        @hook.provide_gcp_credential_file
+        def assert_gcp_credential_file_in_env(hook_instance):
+            self.assertEqual(os.environ[hook._G_APP_CRED_ENV_VAR], key_path)
+
+        assert_gcp_credential_file_in_env(self.instance)
+
+    @mock.patch('tempfile.NamedTemporaryFile')
+    def test_provide_gcp_credential_file_decorator_key_content(self, mock_file):
+        string_file = StringIO()
+        file_content = '{"foo": "bar"}'
+        file_name = '/test/mock-file'
+        self.instance.extras = {'extra__google_cloud_platform__keyfile_dict': file_content}
+        mock_file_handler = mock_file.return_value.__enter__.return_value
+        mock_file_handler.name = file_name
+        mock_file_handler.write = string_file.write
+
+        @hook.provide_gcp_credential_file
+        def assert_gcp_credential_file_in_env(hook_instance):
+            self.assertEqual(os.environ[hook._G_APP_CRED_ENV_VAR], file_name)
+            self.assertEqual(file_content, string_file.getvalue())
+
+        assert_gcp_credential_file_in_env(self.instance)
+
+
+class FixtureClass:
+    def __init__(self, project_id):
+        self.mock = mock.Mock()
+        self.fixture_project_id = project_id
+
+    @hook.fallback_to_default_project_id
+    def method(self, project_id):
+        self.mock(project_id=project_id)
+        return None
+
+    @property
+    def project_id(self):
+        return self.fixture_project_id
+
+
+class fallback_to_default_project_id_TestCase(unittest.TestCase):
+    def test_no_arguments(self):
+        gcp_hook = FixtureClass(321)
+
+        gcp_hook.method()
+
+        gcp_hook.mock.assert_called_once_with(project_id=321)
+
+    def test_default_project_id(self):
+        gcp_hook = FixtureClass(321)
+
+        gcp_hook.method(project_id=None)
+
+        gcp_hook.mock.assert_called_once_with(project_id=321)
+
+    def test_provided_project_id(self):
+        gcp_hook = FixtureClass(321)
+
+        gcp_hook.method(project_id=123)
+
+        gcp_hook.mock.assert_called_once_with(project_id=123)
+
+    def test_restrict_positional_arguments(self):
+        hook = FixtureClass(321)
+
+        with self.assertRaises(AirflowException) as cm:
+            hook.method(123)
+
+        self.assertEqual(
+            str(cm.exception), "You must use keyword arguments in this methods rather than positional"
+        )
+        self.assertEqual(hook.mock.call_count, 0)
+
+
 class TestGoogleCloudBaseHook(unittest.TestCase):
     def setUp(self):
         self.instance = hook.GoogleCloudBaseHook()
 
-    @unittest.skipIf(
-        not default_creds_available,
-        'Default GCP credentials not available to run tests')
+    @unittest.skipIf(not default_creds_available, 'Default GCP credentials not available to run tests')
     def test_default_creds_with_scopes(self):
         self.instance.extras = {
             'extra__google_cloud_platform__project': default_project,
             'extra__google_cloud_platform__scope': (
-                ','.join((
-                    'https://www.googleapis.com/auth/bigquery',
-                    'https://www.googleapis.com/auth/devstorage.read_only',
-                ))
+                ','.join(
+                    (
+                        'https://www.googleapis.com/auth/bigquery',
+                        'https://www.googleapis.com/auth/devstorage.read_only',
+                    )
+                )
             ),
         }
 
@@ -73,16 +156,11 @@ class TestGoogleCloudBaseHook(unittest.TestCase):
 
         scopes = credentials.scopes
         self.assertIn('https://www.googleapis.com/auth/bigquery', scopes)
-        self.assertIn(
-            'https://www.googleapis.com/auth/devstorage.read_only', scopes)
+        self.assertIn('https://www.googleapis.com/auth/devstorage.read_only', scopes)
 
-    @unittest.skipIf(
-        not default_creds_available,
-        'Default GCP credentials not available to run tests')
+    @unittest.skipIf(not default_creds_available, 'Default GCP credentials not available to run tests')
     def test_default_creds_no_scopes(self):
-        self.instance.extras = {
-            'extra__google_cloud_platform__project': default_project,
-        }
+        self.instance.extras = {'extra__google_cloud_platform__project': default_project}
 
         credentials = self.instance._get_credentials()
 
@@ -94,34 +172,28 @@ class TestGoogleCloudBaseHook(unittest.TestCase):
         scopes = credentials.scopes
         self.assertEqual(tuple(hook._DEFAULT_SCOPES), tuple(scopes))
 
-    def test_provide_gcp_credential_file_decorator_key_path(self):
-        key_path = '/test/key-path'
+    def test_provided_scopes(self):
         self.instance.extras = {
-            'extra__google_cloud_platform__key_path': key_path
+            'extra__google_cloud_platform__project': default_project,
+            'extra__google_cloud_platform__scope': (
+                ','.join(
+                    (
+                        'https://www.googleapis.com/auth/bigquery',
+                        'https://www.googleapis.com/auth/devstorage.read_only',
+                    )
+                )
+            ),
         }
 
-        @hook.GoogleCloudBaseHook._Decorators.provide_gcp_credential_file
-        def assert_gcp_credential_file_in_env(hook_instance):
-            self.assertEqual(os.environ[hook._G_APP_CRED_ENV_VAR],
-                             key_path)
-        assert_gcp_credential_file_in_env(self.instance)
+        self.assertEqual(
+            self.instance.scopes,
+            [
+                'https://www.googleapis.com/auth/bigquery',
+                'https://www.googleapis.com/auth/devstorage.read_only',
+            ],
+        )
 
-    @mock.patch('tempfile.NamedTemporaryFile')
-    def test_provide_gcp_credential_file_decorator_key_content(self,
-                                                               mock_file):
-        string_file = StringIO()
-        file_content = '{"foo": "bar"}'
-        file_name = '/test/mock-file'
-        self.instance.extras = {
-            'extra__google_cloud_platform__keyfile_dict': file_content
-        }
-        mock_file_handler = mock_file.return_value.__enter__.return_value
-        mock_file_handler.name = file_name
-        mock_file_handler.write = string_file.write
+    def test_default_scopes(self):
+        self.instance.extras = {'extra__google_cloud_platform__project': default_project}
 
-        @hook.GoogleCloudBaseHook._Decorators.provide_gcp_credential_file
-        def assert_gcp_credential_file_in_env(hook_instance):
-            self.assertEqual(os.environ[hook._G_APP_CRED_ENV_VAR],
-                             file_name)
-            self.assertEqual(file_content, string_file.getvalue())
-        assert_gcp_credential_file_in_env(self.instance)
+        self.assertEqual(self.instance.scopes, ('https://www.googleapis.com/auth/cloud-platform',))


### PR DESCRIPTION
The proposed PR introduces various changes related to GoogleCloudBaseHook:

- Move all decorators to top-level of module.  
   There were two ways to place decorations in the file: 
  1. as a static method on GoogleCloudBaseHook
  2. as a static method on nested class _Decorators in class GoogleCloudBaseHook. 

  In my opinion, the applied level of nesting is unjustified.
  This is also indicated in Google's code style guide: http://google.github.io/styleguide/pyguide.html#217-function-and-method-decorators
- Create property `scope` to separate complex logic from the `get_credentials` method. 
  This allows us to test the code in isolation. Tests have been added.
- Simplify logic of `fallback_to_default_project_id`. 
  The logic of the method has been unnecessarily complicated.  The helper method used was used deleted. There have been added tests to check the code's logic.
- Some code fragment did not follow the line width rule.
- Use `@decoractor` syntax. 
The old syntax is not supported by [autoapi](https://lists.apache.org/list.html?dev@airflow.apache.org:lte=5M:).