### PR TITLE
Extract example DAGs to separate files in doc

### DIFF
--- a/airflow/example_dags/example_bash_operator.py
+++ b/airflow/example_dags/example_bash_operator.py
@@ -72,13 +72,15 @@ also_run_this >> run_this_last
 
 # [START concepts_jinja_templating]
 # The execution date as YYYY-MM-DD
-t = BashOperator(
+test_env = BashOperator(
     task_id='test_env',
     bash_command='/tmp/test.sh ',
     dag=dag,
     env={'EXECUTION_DATE': "{{ ds }}"}
 )
 # [END concepts_jinja_templating]
+also_run_this >> test_env
+
 
 if __name__ == "__main__":
     dag.cli()

--- a/airflow/example_dags/example_branch_python_dop_operator_3.py
+++ b/airflow/example_dags/example_branch_python_dop_operator_3.py
@@ -25,7 +25,7 @@ from airflow.operators.python_operator import BranchPythonOperator
 args = {
     'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(2),
-    'depends_on_past': True,
+    'depends_on_past': False,
 }
 
 # BranchPython operator that depends on past
@@ -33,7 +33,7 @@ args = {
 # alternating runs
 dag = DAG(
     dag_id='example_branch_dop_operator_v3',
-    schedule_interval='*/1 * * * *',
+    schedule_interval='0 0 * * *',
     default_args=args,
 )
 

--- a/airflow/example_dags/example_branch_python_operator.py
+++ b/airflow/example_dags/example_branch_python_operator.py
@@ -18,11 +18,22 @@
 # under the License.
 
 # [START branch_python_operator]
+import airflow
 from airflow.models import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import BranchPythonOperator
 
+args = {
+    'owner': 'airflow',
+    'start_date': airflow.utils.dates.days_ago(2),
+}
+
+dag = DAG(
+    dag_id='example_branch_python_operator',
+    default_args=args,
+    schedule_interval="@daily",
+)
 
 def branch_func(**kwargs):
     ti = kwargs['ti']

--- a/airflow/example_dags/example_branch_python_operator.py
+++ b/airflow/example_dags/example_branch_python_operator.py
@@ -17,27 +17,35 @@
 # specific language governing permissions and limitations
 # under the License.
 
-[START latest_only_with_trigger]
-import datetime as dt
-
-import airflow
+# [START branch_python_operator]
 from airflow.models import DAG
+from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
-from airflow.operators.latest_only_operator import LatestOnlyOperator
-from airflow.utils.trigger_rule import TriggerRule
+from airflow.operators.python_operator import BranchPythonOperator
 
-dag = DAG(
-    dag_id='example_latest_only_with_trigger',
-    schedule_interval=None,
-    start_date=airflow.utils.dates.days_ago(2),
-)
 
-latest_only = LatestOnlyOperator(task_id='latest_only', dag=dag)
-task1 = DummyOperator(task_id='task1', dag=dag)
-task2 = DummyOperator(task_id='task2', dag=dag)
-task3 = DummyOperator(task_id='task3', dag=dag)
-task4 = DummyOperator(task_id='task4', dag=dag, trigger_rule=TriggerRule.ALL_DONE)
+def branch_func(**kwargs):
+    ti = kwargs['ti']
+    xcom_value = int(ti.xcom_pull(task_ids='start_task'))
+    if xcom_value >= 5:
+        return 'continue_task'
+    else:
+        return 'stop_task'
 
-latest_only >> task1 >> [task3, task4]
-task2 >> [task3, task4]
-[END latest_only_with_trigger]
+start_op = BashOperator(
+    task_id='start_task',
+    bash_command="echo 5",
+    xcom_push=True,
+    dag=dag)
+
+branch_op = BranchPythonOperator(
+    task_id='branch_task',
+    provide_context=True,
+    python_callable=branch_func,
+    dag=dag)
+
+continue_op = DummyOperator(task_id='continue_task', dag=dag)
+stop_op = DummyOperator(task_id='stop_task', dag=dag)
+
+start_op >> branch_op >> [continue_op, stop_op]
+# [END branch_python_operator]

--- a/airflow/example_dags/example_default_args.py
+++ b/airflow/example_dags/example_default_args.py
@@ -16,25 +16,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import datetime as dt
 
 import airflow
-from airflow.models import DAG
+from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
-from airflow.operators.latest_only_operator import LatestOnlyOperator
-from airflow.utils.trigger_rule import TriggerRule
 
-dag = DAG(
-    dag_id='example_latest_only_with_trigger',
-    schedule_interval=None,
-    start_date=airflow.utils.dates.days_ago(2),
-)
+default_args = {
+    'start_date': airflow.utils.dates.days_ago(2),
+    'owner': 'Airflow',
+}
 
-latest_only = LatestOnlyOperator(task_id='latest_only', dag=dag)
-task1 = DummyOperator(task_id='task1', dag=dag)
-task2 = DummyOperator(task_id='task2', dag=dag)
-task3 = DummyOperator(task_id='task3', dag=dag)
-task4 = DummyOperator(task_id='task4', dag=dag, trigger_rule=TriggerRule.ALL_DONE)
-
-latest_only >> task1 >> [task3, task4]
-task2 >> [task3, task4]
+dag = DAG('example_default_args', default_args=default_args, schedule_interval=None)
+op = DummyOperator(task_id='dummy', dag=dag)

--- a/airflow/example_dags/example_documentation.py
+++ b/airflow/example_dags/example_documentation.py
@@ -16,25 +16,31 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import datetime as dt
-
+#
+"""
+### My great DAG
+"""
 import airflow
-from airflow.models import DAG
-from airflow.operators.dummy_operator import DummyOperator
-from airflow.operators.latest_only_operator import LatestOnlyOperator
-from airflow.utils.trigger_rule import TriggerRule
+from airflow import DAG
+from airflow.operators.bash_operator import BashOperator
 
-dag = DAG(
-    dag_id='example_latest_only_with_trigger',
-    schedule_interval=None,
-    start_date=airflow.utils.dates.days_ago(2),
+default_args = {
+    'owner': 'airflow',
+    'start_date': airflow.utils.dates.days_ago(2),
+}
+
+# [START concepts_documentation]
+dag = DAG('example_documentation', default_args=default_args, schedule_interval=None)
+dag.doc_md = __doc__
+
+t = BashOperator(
+    bash_command="echo 1",
+    dag=dag,
+    task_id='bash_doc',
 )
+t.doc_md = """\
+    #Title"
+    Here's a [url](www.airbnb.com)
+    """
 
-latest_only = LatestOnlyOperator(task_id='latest_only', dag=dag)
-task1 = DummyOperator(task_id='task1', dag=dag)
-task2 = DummyOperator(task_id='task2', dag=dag)
-task3 = DummyOperator(task_id='task3', dag=dag)
-task4 = DummyOperator(task_id='task4', dag=dag, trigger_rule=TriggerRule.ALL_DONE)
-
-latest_only >> task1 >> [task3, task4]
-task2 >> [task3, task4]
+# [END concepts_documentation]

--- a/airflow/example_dags/example_dynamic_dag.py
+++ b/airflow/example_dags/example_dynamic_dag.py
@@ -16,25 +16,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import datetime as dt
 
-import airflow
-from airflow.models import DAG
-from airflow.operators.dummy_operator import DummyOperator
-from airflow.operators.latest_only_operator import LatestOnlyOperator
-from airflow.utils.trigger_rule import TriggerRule
+# [START faq_dynamic_dag]
+from airflow import DAG
 
-dag = DAG(
-    dag_id='example_latest_only_with_trigger',
-    schedule_interval=None,
-    start_date=airflow.utils.dates.days_ago(2),
-)
-
-latest_only = LatestOnlyOperator(task_id='latest_only', dag=dag)
-task1 = DummyOperator(task_id='task1', dag=dag)
-task2 = DummyOperator(task_id='task2', dag=dag)
-task3 = DummyOperator(task_id='task3', dag=dag)
-task4 = DummyOperator(task_id='task4', dag=dag, trigger_rule=TriggerRule.ALL_DONE)
-
-latest_only >> task1 >> [task3, task4]
-task2 >> [task3, task4]
+for i in range(10):
+    dag_id = 'foo_{}'.format(i)
+    globals()[dag_id] = DAG(dag_id)
+    # or better, call a function that returns a DAG object!
+# [END faq_dynamic_dag]

--- a/airflow/example_dags/example_latest_only.py
+++ b/airflow/example_dags/example_latest_only.py
@@ -27,8 +27,8 @@ from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.latest_only_operator import LatestOnlyOperator
 
 dag = DAG(
-    dag_id='latest_only',
-    schedule_interval=dt.timedelta(hours=4),
+    dag_id='example_latest_only',
+    schedule_interval=None,
     start_date=airflow.utils.dates.days_ago(2),
 )
 

--- a/airflow/example_dags/example_latest_only.py
+++ b/airflow/example_dags/example_latest_only.py
@@ -19,8 +19,6 @@
 """
 Example of the LatestOnlyOperator
 """
-import datetime as dt
-
 import airflow
 from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator

--- a/airflow/example_dags/example_latest_only_with_trigger.py
+++ b/airflow/example_dags/example_latest_only_with_trigger.py
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-[START latest_only_with_trigger]
+# [START latest_only_with_trigger]
 import datetime as dt
 
 import airflow
@@ -40,4 +40,4 @@ task4 = DummyOperator(task_id='task4', dag=dag, trigger_rule=TriggerRule.ALL_DON
 
 latest_only >> task1 >> [task3, task4]
 task2 >> [task3, task4]
-[END latest_only_with_trigger]
+# [END latest_only_with_trigger]

--- a/airflow/example_dags/example_latest_only_with_trigger.py
+++ b/airflow/example_dags/example_latest_only_with_trigger.py
@@ -18,8 +18,6 @@
 # under the License.
 
 # [START latest_only_with_trigger]
-import datetime as dt
-
 import airflow
 from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator

--- a/airflow/example_dags/example_lineage.py
+++ b/airflow/example_dags/example_lineage.py
@@ -26,33 +26,44 @@ from airflow.operators.dummy_operator import DummyOperator
 from airflow.lineage.datasets import File
 from airflow.models import DAG
 
+
 FILE_CATEGORIES = ["CAT1", "CAT2", "CAT3"]
 
-args = {"owner": "airflow", "start_date": airflow.utils.dates.days_ago(2)}
+args = {
+    'owner': 'airflow',
+    'start_date': airflow.utils.dates.days_ago(2)
+}
 
 dag = DAG(
-    dag_id="example_lineage",
+    dag_id='example_lineage', 
     default_args=args,
-    schedule_interval=None,
-    dagrun_timeout=timedelta(minutes=60),
+    schedule_interval='0 0 * * *',
+    dagrun_timeout=timedelta(minutes=60)
 )
 
 f_final = File("/tmp/final")
+
 run_this_last = DummyOperator(
-    task_id="run_this_last", dag=dag, inlets={"auto": True}, outlets={"datasets": [f_final]}
+    task_id='run_this_last', 
+    dag=dag, 
+    inlets={"auto": True},
+    outlets={"datasets": [f_final]}
 )
 
 f_in = File("/tmp/whole_directory/")
+
 outlets = []
 for file in FILE_CATEGORIES:
     f_out = File("/tmp/{}/{{{{ execution_date }}}}".format(file))
     outlets.append(f_out)
-run_this = BashOperator(
-    task_id="run_me_first",
-    bash_command="echo 1",
-    dag=dag,
+
+run_this = BashOperator(    
+    task_id='run_me_first',
+    dag=dag, 
+    bash_command='echo 1', 
     inlets={"datasets": [f_in]},
-    outlets={"datasets": outlets},
+    outlets={"datasets": outlets}
 )
+
 run_this.set_downstream(run_this_last)
 # [END lineage]

--- a/airflow/example_dags/example_lineage.py
+++ b/airflow/example_dags/example_lineage.py
@@ -35,7 +35,7 @@ args = {
 }
 
 dag = DAG(
-    dag_id='example_lineage', 
+    dag_id='example_lineage',
     default_args=args,
     schedule_interval='0 0 * * *',
     dagrun_timeout=timedelta(minutes=60)
@@ -44,8 +44,8 @@ dag = DAG(
 f_final = File("/tmp/final")
 
 run_this_last = DummyOperator(
-    task_id='run_this_last', 
-    dag=dag, 
+    task_id='run_this_last',
+    dag=dag,
     inlets={"auto": True},
     outlets={"datasets": [f_final]}
 )
@@ -57,10 +57,10 @@ for file in FILE_CATEGORIES:
     f_out = File("/tmp/{}/{{{{ execution_date }}}}".format(file))
     outlets.append(f_out)
 
-run_this = BashOperator(    
+run_this = BashOperator(
     task_id='run_me_first',
-    dag=dag, 
-    bash_command='echo 1', 
+    dag=dag,
+    bash_command='echo 1',
     inlets={"datasets": [f_in]},
     outlets={"datasets": outlets}
 )

--- a/airflow/example_dags/example_trigger_controller_dag.py
+++ b/airflow/example_dags/example_trigger_controller_dag.py
@@ -54,7 +54,7 @@ def conditionally_trigger(context, dag_run_obj):
 
 # Define the DAG
 dag = DAG(
-    dag_id='example_trigger_controller_dag',
+    dag_id='example_trigger_controller',
     default_args={
         "owner": "airflow",
         "start_date": datetime.utcnow(),

--- a/airflow/example_dags/subdags/main_dag.py
+++ b/airflow/example_dags/subdags/main_dag.py
@@ -34,8 +34,12 @@ main_dag = DAG(
 )
 
 sub_dag = SubDagOperator(
-    subdag=sub_dag(PARENT_DAG_NAME, CHILD_DAG_NAME, main_dag.start_date,
-                    main_dag.schedule_interval),
+    subdag=sub_dag(
+        PARENT_DAG_NAME,
+        CHILD_DAG_NAME,
+        main_dag.start_date,
+        main_dag.schedule_interval
+    ),
     task_id=CHILD_DAG_NAME,
     dag=main_dag,
 )

--- a/airflow/example_dags/subdags/main_dag.py
+++ b/airflow/example_dags/subdags/main_dag.py
@@ -17,27 +17,26 @@
 # specific language governing permissions and limitations
 # under the License.
 
-[START latest_only_with_trigger]
-import datetime as dt
-
-import airflow
+# [START main_dag]
+from datetime import datetime, timedelta
 from airflow.models import DAG
-from airflow.operators.dummy_operator import DummyOperator
-from airflow.operators.latest_only_operator import LatestOnlyOperator
-from airflow.utils.trigger_rule import TriggerRule
+from airflow.operators.subdag_operator import SubDagOperator
+from dags.subdag import sub_dag
 
-dag = DAG(
-    dag_id='example_latest_only_with_trigger',
-    schedule_interval=None,
-    start_date=airflow.utils.dates.days_ago(2),
+
+PARENT_DAG_NAME = 'parent_dag'
+CHILD_DAG_NAME = 'child_dag'
+
+main_dag = DAG(
+    dag_id=PARENT_DAG_NAME,
+    schedule_interval=timedelta(hours=1),
+    start_date=datetime(2016, 1, 1)
 )
 
-latest_only = LatestOnlyOperator(task_id='latest_only', dag=dag)
-task1 = DummyOperator(task_id='task1', dag=dag)
-task2 = DummyOperator(task_id='task2', dag=dag)
-task3 = DummyOperator(task_id='task3', dag=dag)
-task4 = DummyOperator(task_id='task4', dag=dag, trigger_rule=TriggerRule.ALL_DONE)
-
-latest_only >> task1 >> [task3, task4]
-task2 >> [task3, task4]
-[END latest_only_with_trigger]
+sub_dag = SubDagOperator(
+    subdag=sub_dag(PARENT_DAG_NAME, CHILD_DAG_NAME, main_dag.start_date,
+                    main_dag.schedule_interval),
+    task_id=CHILD_DAG_NAME,
+    dag=main_dag,
+)
+# [END main_dag]

--- a/airflow/example_dags/subdags/subdag.py
+++ b/airflow/example_dags/subdags/subdag.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# [START subdag]
 from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
 
@@ -36,3 +37,4 @@ def subdag(parent_dag_name, child_dag_name, args):
         )
 
     return dag_subdag
+# [END subdag]

--- a/airflow/example_dags/tutorial.py
+++ b/airflow/example_dags/tutorial.py
@@ -22,8 +22,10 @@
 Documentation that goes along with the Airflow tutorial located
 [here](https://airflow.apache.org/tutorial.html)
 """
+# [START tutorial_example_pipeline_definition]
 from datetime import timedelta
 
+# [START scheduler_backfill_and_catchup]
 import airflow
 from airflow import DAG
 from airflow.operators.bash_operator import BashOperator
@@ -60,6 +62,7 @@ dag = DAG(
     description='A simple tutorial DAG',
     schedule_interval=timedelta(days=1),
 )
+# [END scheduler_backfill_and_catchup]
 
 # t1, t2 and t3 are examples of tasks created by instantiating operators
 t1 = BashOperator(
@@ -102,3 +105,4 @@ t3 = BashOperator(
 )
 
 t1 >> [t2, t3]
+# [END tutorial_example_pipeline_definition]

--- a/airflow/example_dags/tutorial.py
+++ b/airflow/example_dags/tutorial.py
@@ -120,4 +120,4 @@ t3 = BashOperator(
 
 t1 >> [t2, t3]
 
-#[END tutorial]
+# [END tutorial]

--- a/airflow/example_dags/tutorial.py
+++ b/airflow/example_dags/tutorial.py
@@ -22,8 +22,8 @@
 Documentation that goes along with the Airflow tutorial located
 [here](https://airflow.apache.org/tutorial.html)
 """
-# [START tutorial_example_pipeline_definition]
-from datetime import timedelta
+# [START tutorial]
+from datetime import datetime, timedelta
 
 # [START scheduler_backfill_and_catchup]
 import airflow
@@ -35,7 +35,7 @@ from airflow.operators.bash_operator import BashOperator
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': datetime(2015, 12, 1),
     'email': ['airflow@example.com'],
     'email_on_failure': False,
     'email_on_retry': False,
@@ -60,7 +60,7 @@ dag = DAG(
     'tutorial',
     default_args=default_args,
     description='A simple tutorial DAG',
-    schedule_interval=timedelta(days=1),
+    schedule_interval='@daily',
 )
 # [END scheduler_backfill_and_catchup]
 
@@ -85,6 +85,7 @@ t2 = BashOperator(
     task_id='sleep',
     depends_on_past=False,
     bash_command='sleep 5',
+    retries=3,
     dag=dag,
 )
 
@@ -105,4 +106,4 @@ t3 = BashOperator(
 )
 
 t1 >> [t2, t3]
-# [END tutorial_example_pipeline_definition]
+#[END tutorial]

--- a/airflow/example_dags/tutorial.py
+++ b/airflow/example_dags/tutorial.py
@@ -26,12 +26,14 @@ Documentation that goes along with the Airflow tutorial located
 from datetime import datetime, timedelta
 
 # [START scheduler_backfill_and_catchup]
-import airflow
+# [START tutorial_import_modules]
 from airflow import DAG
 from airflow.operators.bash_operator import BashOperator
+# [END tutorial_import_modules]
 
 # These args will get passed on to each operator
 # You can override them on a per-task basis during operator initialization
+# [START tutorial_default_arguments]
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
@@ -55,21 +57,27 @@ default_args = {
     # 'on_retry_callback': another_function,
     # 'trigger_rule': u'all_success'
 }
+# [END tutorial_default_arguments]
 
+# [START tutorial_init_dag]
 dag = DAG(
     'tutorial',
     default_args=default_args,
     description='A simple tutorial DAG',
     schedule_interval='@daily',
 )
+# [END tutorial_init_dag]
 # [END scheduler_backfill_and_catchup]
 
 # t1, t2 and t3 are examples of tasks created by instantiating operators
+# [START tutorial_task1]
+# [START tutorial_task1_without_doc]
 t1 = BashOperator(
     task_id='print_date',
     bash_command='date',
     dag=dag,
 )
+# [END tutorial_task1_without_doc]
 
 t1.doc_md = """\
 #### Task Documentation
@@ -80,7 +88,9 @@ rendered in the UI's Task Instance Details page.
 """
 
 dag.doc_md = __doc__
+# [END tutorial_task1]
 
+# [START tutorial_task2]
 t2 = BashOperator(
     task_id='sleep',
     depends_on_past=False,
@@ -88,7 +98,9 @@ t2 = BashOperator(
     retries=3,
     dag=dag,
 )
+# [END tutorial_task2]
 
+# [START tutorial_task3]
 templated_command = """
 {% for i in range(5) %}
     echo "{{ ds }}"
@@ -104,6 +116,8 @@ t3 = BashOperator(
     params={'my_param': 'Parameter I passed in'},
     dag=dag,
 )
+# [END tutorial_task3]
 
 t1 >> [t2, t3]
+
 #[END tutorial]

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -43,15 +43,33 @@ class AirflowPluginException(Exception):
     pass
 
 
+# [START plugins_interface]
 class AirflowPlugin(object):
+    hooks = []
+    executors = []
+    macros = []
+    admin_views = []
+    flask_blueprints = []
+    menu_links = []
+    appbuilder_views = []
+    appbuilder_menu_items = []
+    # The name of your plugin (str)
     name = None  # type: str
+    # A list of class(es) derived from BaseOperator
     operators = []  # type: List[Any]
+    # A list of class(es) derived from BaseSensorOperator
     sensors = []  # type: List[Any]
+    # A list of class(es) derived from BaseHook
     hooks = []  # type: List[Any]
+    # A list of class(es) derived from BaseExecutor
     executors = []  # type: List[Any]
+    # A list of references to inject into the macros namespace
     macros = []  # type: List[Any]
+    # A list of Blueprint object created from flask.Blueprint. For use with the flask_appbuilder based GUI
     admin_views = []  # type: List[Any]
+    # A list of dictionaries containing FlaskAppBuilder BaseView object and some metadata. See example below
     flask_blueprints = []  # type: List[Any]
+    # A list of dictionaries containing FlaskAppBuilder BaseView object and some metadata. See example below
     menu_links = []  # type: List[Any]
     appbuilder_views = []  # type: List[Any]
     appbuilder_menu_items = []  # type: List[Any]
@@ -67,10 +85,15 @@ class AirflowPlugin(object):
         Executed when the plugin is loaded.
         This method is only called once during runtime.
 
+        Ensure your plugin has *args, and **kwargs in the method definition
+        to protect against extra parameters injected into the on_load(...)
+        function in future changes
+
         :param args: If future arguments are passed in on call.
         :param kwargs: If future arguments are passed in on call.
         """
         pass
+# [END plugins_interface]
 
 
 def load_entrypoint_plugins(entry_points, airflow_plugins):

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -32,6 +32,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 ###########################################################################
 #                               VIEW MENUS
 ###########################################################################
+# [START security_viewer_vms]
 VIEWER_VMS = {
     'Airflow',
     'DagModelView',
@@ -53,9 +54,11 @@ VIEWER_VMS = {
     'Version',
     'VersionView',
 }
+# [END security_viewer_vms]
 
 USER_VMS = VIEWER_VMS
 
+# [START security_op_vms]
 OP_VMS = {
     'Admin',
     'Configurations',
@@ -69,11 +72,13 @@ OP_VMS = {
     'XComs',
     'XComModelView',
 }
+# [END security_op_vms]
 
 ###########################################################################
 #                               PERMISSIONS
 ###########################################################################
 
+# [START security_viewer_perms]
 VIEWER_PERMS = {
     'menu_access',
     'can_index',
@@ -100,7 +105,9 @@ VIEWER_PERMS = {
     'can_pickle_info',
     'can_version',
 }
+# [END security_viewer_perms]
 
+# [START security_user_perms]
 USER_PERMS = {
     'can_dagrun_clear',
     'can_run',
@@ -118,17 +125,21 @@ USER_PERMS = {
     'clear',
     'can_clear',
 }
+# [END security_user_perms]
 
+# [START security_op_perms]
 OP_PERMS = {
     'can_conf',
     'can_varimport',
 }
+# [END security_op_perms]
 
 # global view-menu for dag-level access
 DAG_VMS = {
     'all_dags'
 }
 
+# [START security_dag_perms]
 WRITE_DAG_PERMS = {
     'can_dag_edit',
 }
@@ -138,6 +149,7 @@ READ_DAG_PERMS = {
 }
 
 DAG_PERMS = WRITE_DAG_PERMS | READ_DAG_PERMS
+# [END security_dag_perms]
 
 ###########################################################################
 #                     DEFAULT ROLE CONFIGURATIONS

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -353,6 +353,16 @@ def get_attr_renderer():
     }
 
 
+def render_attrs(task):
+    attrs_rendered = {}
+    for attr_name in get_attr_renderer():
+        if hasattr(task, attr_name):
+            source = getattr(task, attr_name)
+            attrs_rendered[attr_name] = \
+                get_attr_renderer()[attr_name](source)
+    return attrs_rendered
+
+
 def recurse_tasks(tasks, task_ids, dag_ids, task_id_to_dag):
     if isinstance(tasks, list):
         for task in tasks:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -662,12 +662,7 @@ class Airflow(AirflowBaseView):
                     task_attrs.append((attr_name, str(attr)))
 
         # Color coding the special attributes that are code
-        special_attrs_rendered = {}
-        for attr_name in wwwutils.get_attr_renderer():
-            if hasattr(task, attr_name):
-                source = getattr(task, attr_name)
-                special_attrs_rendered[attr_name] = \
-                    wwwutils.get_attr_renderer()[attr_name](source)
+        special_attrs_rendered = self.render_attrs(task)
 
         no_failed_deps_result = [(
             "Unknown",

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -15,6 +15,8 @@
     specific language governing permissions and limitations
     under the License.
 
+.. _command_line_interface:
+
 Command Line Interface
 ======================
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -939,20 +939,11 @@ This is especially useful if your tasks are built dynamically from
 configuration files, it allows you to expose the configuration that led
 to the related tasks in Airflow.
 
-.. code:: python
+.. literalinclude:: ../airflow/example_dags/example_documentation.py
+    :language: python
+    :start-after: [START concepts_documentation]
+    :end-before: [END concepts_documentation]
 
-    """
-    ### My great DAG
-    """
-
-    dag = DAG('my_dag', default_args=default_args)
-    dag.doc_md = __doc__
-
-    t = BashOperator("foo", dag=dag)
-    t.doc_md = """\
-    #Title"
-    Here's a [url](www.airbnb.com)
-    """
 
 This content will get rendered as markdown respectively in the "Graph View" and
 "Task Details" pages.
@@ -969,15 +960,11 @@ powerful tool to use in combination with macros (see the :ref:`macros` section).
 For example, say you want to pass the execution date as an environment variable
 to a Bash script using the ``BashOperator``.
 
-.. code:: python
+.. literalinclude:: ./airflow/example_dags/example_bash_operator.py
+    :language: python
+    :start-after: [START concepts_jinja_templating]
+    :end-before: [END concepts_jinja_templating]
 
-  # The execution date as YYYY-MM-DD
-  date = "{{ ds }}"
-  t = BashOperator(
-      task_id='test_env',
-      bash_command='/tmp/test.sh ',
-      dag=dag,
-      env={'EXECUTION_DATE': date})
 
 Here, ``{{ ds }}`` is a macro, and because the ``env`` parameter of the
 ``BashOperator`` is templated with Jinja, the execution date will be available

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -552,32 +552,11 @@ The ``BranchPythonOperator`` can also be used with XComs allowing branching
 context to dynamically decide what branch to follow based on previous tasks.
 For example:
 
-.. code:: python
+.. literalinclude:: ../airflow/example_dags/example_branch_python_operator.py
+    :language: python
+    :start-after: [START branch_python_operator]
+    :end-before: [END branch_python_operator]
 
-  def branch_func(**kwargs):
-      ti = kwargs['ti']
-      xcom_value = int(ti.xcom_pull(task_ids='start_task'))
-      if xcom_value >= 5:
-          return 'continue_task'
-      else:
-          return 'stop_task'
-
-  start_op = BashOperator(
-      task_id='start_task',
-      bash_command="echo 5",
-      xcom_push=True,
-      dag=dag)
-
-  branch_op = BranchPythonOperator(
-      task_id='branch_task',
-      provide_context=True,
-      python_callable=branch_func,
-      dag=dag)
-
-  continue_op = DummyOperator(task_id='continue_task', dag=dag)
-  stop_op = DummyOperator(task_id='stop_task', dag=dag)
-
-  start_op >> branch_op >> [continue_op, stop_op]
 
 SubDAGs
 =======
@@ -603,54 +582,17 @@ Note that SubDAG operators should contain a factory method that returns a DAG
 object. This will prevent the SubDAG from being treated like a separate DAG in
 the main UI. For example:
 
-.. code:: python
-
-  #dags/subdag.py
-  from airflow.models import DAG
-  from airflow.operators.dummy_operator import DummyOperator
-
-
-  # Dag is returned by a factory method
-  def sub_dag(parent_dag_name, child_dag_name, start_date, schedule_interval):
-    dag = DAG(
-      '%s.%s' % (parent_dag_name, child_dag_name),
-      schedule_interval=schedule_interval,
-      start_date=start_date,
-    )
-
-    dummy_operator = DummyOperator(
-      task_id='dummy_task',
-      dag=dag,
-    )
-
-    return dag
+.. literalinclude:: ../airflow/example_dags/subdags/subdag.py
+    :language: python
+    :start-after: [START subdag]
+    :end-before: [END subdag]
 
 This SubDAG can then be referenced in your main DAG file:
 
-.. code:: python
-
-  # main_dag.py
-  from datetime import datetime, timedelta
-  from airflow.models import DAG
-  from airflow.operators.subdag_operator import SubDagOperator
-  from dags.subdag import sub_dag
-
-
-  PARENT_DAG_NAME = 'parent_dag'
-  CHILD_DAG_NAME = 'child_dag'
-
-  main_dag = DAG(
-    dag_id=PARENT_DAG_NAME,
-    schedule_interval=timedelta(hours=1),
-    start_date=datetime(2016, 1, 1)
-  )
-
-  sub_dag = SubDagOperator(
-    subdag=sub_dag(PARENT_DAG_NAME, CHILD_DAG_NAME, main_dag.start_date,
-                   main_dag.schedule_interval),
-    task_id=CHILD_DAG_NAME,
-    dag=main_dag,
-  )
+.. literalinclude:: ../airflow/example_dags/subdags/main_dag.py
+    :language: python
+    :start-after: [START main_dag]
+    :end-before: [END main_dag]
 
 You can zoom into a SubDagOperator from the graph view of the main DAG to show
 the tasks contained within the SubDAG:
@@ -826,6 +768,7 @@ right now is not between its ``execution_time`` and the next scheduled
 
 For example, consider the following DAG:
 
+<<<<<<< HEAD
 .. code:: python
 
   #dags/latest_only_with_trigger.py
@@ -856,6 +799,12 @@ For example, consider the following DAG:
   task4 = DummyOperator(task_id='task4', dag=dag,
                         trigger_rule=TriggerRule.ALL_DONE)
   task4.set_upstream([task1, task2])
+=======
+.. literalinclude:: ../airflow/example_dags/example_latest_only_with_trigger.py
+    :language: python
+    :start-after: [START latest_only_with_trigger]
+    :end-before: [END latest_only_with_trigger]
+>>>>>>> Extract example DAGs to separate files in doc
 
 In the case of this DAG, the ``latest_only`` task will show up as skipped
 for all runs except the latest run. ``task1`` is directly downstream of

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -768,43 +768,10 @@ right now is not between its ``execution_time`` and the next scheduled
 
 For example, consider the following DAG:
 
-<<<<<<< HEAD
-.. code:: python
-
-  #dags/latest_only_with_trigger.py
-  import datetime as dt
-
-  from airflow.models import DAG
-  from airflow.operators.dummy_operator import DummyOperator
-  from airflow.operators.latest_only_operator import LatestOnlyOperator
-  from airflow.utils.trigger_rule import TriggerRule
-
-
-  dag = DAG(
-      dag_id='latest_only_with_trigger',
-      schedule_interval=dt.timedelta(hours=1),
-      start_date=dt.datetime(2019, 2, 28),
-  )
-
-  latest_only = LatestOnlyOperator(task_id='latest_only', dag=dag)
-
-  task1 = DummyOperator(task_id='task1', dag=dag)
-  task1.set_upstream(latest_only)
-
-  task2 = DummyOperator(task_id='task2', dag=dag)
-
-  task3 = DummyOperator(task_id='task3', dag=dag)
-  task3.set_upstream([task1, task2])
-
-  task4 = DummyOperator(task_id='task4', dag=dag,
-                        trigger_rule=TriggerRule.ALL_DONE)
-  task4.set_upstream([task1, task2])
-=======
 .. literalinclude:: ../airflow/example_dags/example_latest_only_with_trigger.py
     :language: python
     :start-after: [START latest_only_with_trigger]
     :end-before: [END latest_only_with_trigger]
->>>>>>> Extract example DAGs to separate files in doc
 
 In the case of this DAG, the ``latest_only`` task will show up as skipped
 for all runs except the latest run. ``task1`` is directly downstream of

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -145,12 +145,10 @@ variable in the global namespace, which is easily done in python using the
 ``globals()`` function for the standard library which behaves like a
 simple dictionary.
 
-.. code:: python
-
-    for i in range(10):
-        dag_id = 'foo_{}'.format(i)
-        globals()[dag_id] = DAG(dag_id)
-        # or better, call a function that returns a DAG object!
+.. literalinclude:: ../airflow/example_dags/example_dynamic_dag.py
+    :language: python
+    :start-after: [START faq_dynamic_dag]
+    :end-before: [END faq_dynamic_dag]
 
 What are all the ``airflow run`` commands in my process list?
 ---------------------------------------------------------------

--- a/docs/kubernetes.rst
+++ b/docs/kubernetes.rst
@@ -42,102 +42,10 @@ The volumes are optional and depend on your configuration. There are two volumes
 Kubernetes Operator
 ^^^^^^^^^^^^^^^^^^^
 
-.. code:: python
-
-    from airflow.contrib.operators import KubernetesOperator
-    from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
-    from airflow.contrib.kubernetes.secret import Secret
-    from airflow.contrib.kubernetes.volume import Volume
-    from airflow.contrib.kubernetes.volume_mount import VolumeMount
-
-
-    secret_file = Secret('volume', '/etc/sql_conn', 'airflow-secrets', 'sql_alchemy_conn')
-    secret_env  = Secret('env', 'SQL_CONN', 'airflow-secrets', 'sql_alchemy_conn')
-    volume_mount = VolumeMount('test-volume',
-                                mount_path='/root/mount_file',
-                                sub_path=None,
-                                read_only=True)
-
-    volume_config= {
-        'persistentVolumeClaim':
-          {
-            'claimName': 'test-volume'
-          }
-        }
-    volume = Volume(name='test-volume', configs=volume_config)
-
-    affinity = {
-        'nodeAffinity': {
-          'preferredDuringSchedulingIgnoredDuringExecution': [
-            {
-              "weight": 1,
-              "preference": {
-                "matchExpressions": {
-                  "key": "disktype",
-                  "operator": "In",
-                  "values": ["ssd"]
-                }
-              }
-            }
-          ]
-        },
-        "podAffinity": {
-          "requiredDuringSchedulingIgnoredDuringExecution": [
-            {
-              "labelSelector": {
-                "matchExpressions": [
-                  {
-                    "key": "security",
-                    "operator": "In",
-                    "values": ["S1"]
-                  }
-                ]
-              },
-              "topologyKey": "failure-domain.beta.kubernetes.io/zone"
-            }
-          ]
-        },
-        "podAntiAffinity": {
-          "requiredDuringSchedulingIgnoredDuringExecution": [
-            {
-              "labelSelector": {
-                "matchExpressions": [
-                  {
-                    "key": "security",
-                    "operator": "In",
-                    "values": ["S2"]
-                  }
-                ]
-              },
-              "topologyKey": "kubernetes.io/hostname"
-            }
-          ]
-        }
-    }
-
-    tolerations = [
-        {
-            'key': "key",
-            'operator': 'Equal',
-            'value': 'value'
-         }
-    ]
-
-    k = KubernetesPodOperator(namespace='default',
-                              image="ubuntu:16.04",
-                              cmds=["bash", "-cx"],
-                              arguments=["echo", "10"],
-                              labels={"foo": "bar"},
-                              secrets=[secret_file,secret_env]
-                              volumes=[volume],
-                              volume_mounts=[volume_mount]
-                              name="test",
-                              task_id="task",
-                              affinity=affinity,
-                              is_delete_operator_pod=True,
-                              hostnetwork=False,
-                              tolerations=tolerations
-                              )
+.. literalinclude:: ../airflow/example_dags/example_kubernetes.py
+    :language: python
+    :start-after: [START kubernetes_operator]
+    :end-before: [END kubernetes_operator]
 
 
 .. autoclass:: airflow.contrib.operators.kubernetes_pod_operator.KubernetesPodOperator

--- a/docs/lineage.rst
+++ b/docs/lineage.rst
@@ -26,42 +26,10 @@ audit trails and data governance, but also debugging of data flows.
 Airflow tracks data by means of inlets and outlets of the tasks. Let's work from an example and see how it
 works.
 
-.. code:: python
-
-    from airflow.operators.bash_operator import BashOperator
-    from airflow.operators.dummy_operator import DummyOperator
-    from airflow.lineage.datasets import File
-    from airflow.models import DAG
-    from datetime import timedelta
-    
-    FILE_CATEGORIES = ["CAT1", "CAT2", "CAT3"]
-    
-    args = {
-        'owner': 'airflow',
-        'start_date': airflow.utils.dates.days_ago(2)
-    }
-    
-    dag = DAG(
-        dag_id='example_lineage', default_args=args,
-        schedule_interval='0 0 * * *',
-        dagrun_timeout=timedelta(minutes=60))
-    
-    f_final = File("/tmp/final")
-    run_this_last = DummyOperator(task_id='run_this_last', dag=dag, 
-        inlets={"auto": True},
-        outlets={"datasets": [f_final,]})
-    
-    f_in = File("/tmp/whole_directory/")
-    outlets = []
-    for file in FILE_CATEGORIES:
-        f_out = File("/tmp/{}/{{{{ execution_date }}}}".format(file))
-        outlets.append(f_out)
-    run_this = BashOperator(    
-        task_id='run_me_first', bash_command='echo 1', dag=dag,
-        inlets={"datasets": [f_in,]},
-        outlets={"datasets": outlets}
-        )
-    run_this.set_downstream(run_this_last)
+.. literalinclude:: ../airflow/example_dags/example_lineage.py
+    :language: python
+    :start-after: [START lineage]
+    :end-before: [END lineage]
 
 
 Tasks take the parameters `inlets` and `outlets`.

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -70,37 +70,10 @@ To create a plugin you will need to derive the
 you want to plug into Airflow. Here's what the class you need to derive
 looks like:
 
-
-.. code:: python
-
-    class AirflowPlugin(object):
-        # The name of your plugin (str)
-        name = None
-        # A list of class(es) derived from BaseOperator
-        operators = []
-        # A list of class(es) derived from BaseSensorOperator
-        sensors = []
-        # A list of class(es) derived from BaseHook
-        hooks = []
-        # A list of class(es) derived from BaseExecutor
-        executors = []
-        # A list of references to inject into the macros namespace
-        macros = []
-        # A list of Blueprint object created from flask.Blueprint. For use with the flask_appbuilder based GUI
-        flask_blueprints = []
-        # A list of dictionaries containing FlaskAppBuilder BaseView object and some metadata. See example below
-        appbuilder_views = []
-        # A list of dictionaries containing FlaskAppBuilder BaseView object and some metadata. See example below
-        appbuilder_menu_items = []
-        # A callback to perform actions when airflow starts and the plugin is loaded.
-        # NOTE: Ensure your plugin has *args, and **kwargs in the method definition
-        #   to protect against extra parameters injected into the on_load(...)
-        #   function in future changes
-        def on_load(*args, **kwargs):
-           # ... perform Plugin boot actions
-           pass
-
-
+.. literalinclude:: ../../../airflow/plugins_manager.py
+    :language: python
+    :start-after: [START plugins_interface]
+    :end-before: [END plugins_interface]
 
 
 You can derive it by inheritance (please refer to the example below).
@@ -131,78 +104,10 @@ Example
 The code below defines a plugin that injects a set of dummy object
 definitions in Airflow.
 
-.. code:: python
-
-    # This is the class you derive to create a plugin
-    from airflow.plugins_manager import AirflowPlugin
-
-    from flask import Blueprint
-    from flask_appbuilder import expose, BaseView as AppBuilderBaseView
-
-    # Importing base classes that we need to derive
-    from airflow.hooks.base_hook import BaseHook
-    from airflow.models import BaseOperator
-    from airflow.sensors.base_sensor_operator import BaseSensorOperator
-    from airflow.executors.base_executor import BaseExecutor
-
-    # Will show up under airflow.hooks.test_plugin.PluginHook
-    class PluginHook(BaseHook):
-        pass
-
-    # Will show up under airflow.operators.test_plugin.PluginOperator
-    class PluginOperator(BaseOperator):
-        pass
-
-    # Will show up under airflow.sensors.test_plugin.PluginSensorOperator
-    class PluginSensorOperator(BaseSensorOperator):
-        pass
-
-    # Will show up under airflow.executors.test_plugin.PluginExecutor
-    class PluginExecutor(BaseExecutor):
-        pass
-
-    # Will show up under airflow.macros.test_plugin.plugin_macro
-    def plugin_macro():
-        pass
-
-    # Creating a flask blueprint to integrate the templates and static folder
-    bp = Blueprint(
-        "test_plugin", __name__,
-        template_folder='templates', # registers airflow/plugins/templates as a Jinja template folder
-        static_folder='static',
-        static_url_path='/static/test_plugin')
-
-    # Creating a flask appbuilder BaseView
-    class TestAppBuilderBaseView(AppBuilderBaseView):
-        default_view = "test"
-
-        @expose("/")
-        def test(self):
-            return self.render("test_plugin/test.html", content="Hello galaxy!")
-
-    v_appbuilder_view = TestAppBuilderBaseView()
-    v_appbuilder_package = {"name": "Test View",
-                            "category": "Test Plugin",
-                            "view": v_appbuilder_view}
-
-    # Creating a flask appbuilder Menu Item
-    appbuilder_mitem = {"name": "Google",
-                        "category": "Search",
-                        "category_icon": "fa-th",
-                        "href": "https://www.google.com"}
-
-    # Defining the plugin class
-    class AirflowTestPlugin(AirflowPlugin):
-        name = "test_plugin"
-        operators = [PluginOperator]
-        sensors = [PluginSensorOperator]
-        hooks = [PluginHook]
-        executors = [PluginExecutor]
-        macros = [plugin_macro]
-        flask_blueprints = [bp]
-        appbuilder_views = [v_appbuilder_package]
-        appbuilder_menu_items = [appbuilder_mitem]
-
+.. literalinclude:: ../airflow/tests/plugins/test_plugin.py
+    :language: python
+    :start-after: [START plugins_example]
+    :end-before: [END plugins_example]
 
 Note on role based views
 ------------------------

--- a/docs/scheduler.rst
+++ b/docs/scheduler.rst
@@ -110,7 +110,7 @@ False``) or by default at the configuration file level with ``catchup_by_default
 will do, is to instruct the scheduler to only create a DAG Run for the most current instance of the DAG
 interval series.
 
-.. literalinclude:: ../../../airflow/example_dags/tutorial.py
+.. literalinclude:: ../airflow/example_dags/tutorial.py
     :language: python
     :start-after: [START scheduler_backfill_and_catchup]
     :end-before: [END scheduler_backfill_and_catchup]

--- a/docs/scheduler.rst
+++ b/docs/scheduler.rst
@@ -110,34 +110,10 @@ False``) or by default at the configuration file level with ``catchup_by_default
 will do, is to instruct the scheduler to only create a DAG Run for the most current instance of the DAG
 interval series.
 
-.. code:: python
-
-    """
-    Code that goes along with the Airflow tutorial located at:
-    https://github.com/apache/airflow/blob/master/airflow/example_dags/tutorial.py
-    """
-    from airflow import DAG
-    from airflow.operators.bash_operator import BashOperator
-    from datetime import datetime, timedelta
-
-
-    default_args = {
-        'owner': 'airflow',
-        'depends_on_past': False,
-        'start_date': datetime(2015, 12, 1),
-        'email': ['airflow@example.com'],
-        'email_on_failure': False,
-        'email_on_retry': False,
-        'retries': 1,
-        'retry_delay': timedelta(minutes=5)
-    }
-
-    dag = DAG(
-        'tutorial',
-        default_args=default_args,
-        description='A simple tutorial DAG',
-        schedule_interval='@daily',
-        catchup=False)
+.. literalinclude:: ../../../airflow/example_dags/tutorial.py
+    :language: python
+    :start-after: [START scheduler_backfill_and_catchup]
+    :end-before: [END scheduler_backfill_and_catchup]
 
 In the example above, if the DAG is picked up by the scheduler daemon on 2016-01-02 at 6 AM, (or from the
 command line), a single DAG Run will be created, with an ``execution_date`` of 2016-01-01, and the next

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -449,84 +449,26 @@ Viewer
 ^^^^^^
 ``Viewer`` users have limited viewer permissions
 
-.. code:: python
-
-    VIEWER_PERMS = {
-        'menu_access',
-        'can_index',
-        'can_list',
-        'can_show',
-        'can_chart',
-        'can_dag_stats',
-        'can_dag_details',
-        'can_task_stats',
-        'can_code',
-        'can_log',
-        'can_get_logs_with_metadata',
-        'can_tries',
-        'can_graph',
-        'can_tree',
-        'can_task',
-        'can_task_instances',
-        'can_xcom',
-        'can_gantt',
-        'can_landing_times',
-        'can_duration',
-        'can_blocked',
-        'can_rendered',
-        'can_pickle_info',
-        'can_version',
-    }
+.. literalinclude:: ../airflow/www/security.py
+    :language: python
+    :start-after: [START security_viewer_perms]
+    :end-before: [END security_viewer_perms]
 
 on limited web views
 
-.. code:: python
-
-    VIEWER_VMS = {
-        'Airflow',
-        'DagModelView',
-        'Browse',
-        'DAG Runs',
-        'DagRunModelView',
-        'Task Instances',
-        'TaskInstanceModelView',
-        'SLA Misses',
-        'SlaMissModelView',
-        'Jobs',
-        'JobModelView',
-        'Logs',
-        'LogModelView',
-        'Docs',
-        'Documentation',
-        'GitHub',
-        'About',
-        'Version',
-        'VersionView',
-    }
+.. literalinclude:: ../airflow/www/security.py
+    :language: python
+    :start-after: [START security_viewer_vms]
+    :end-before: [END security_viewer_vms]
 
 User
 ^^^^
 ``User`` users have ``Viewer`` permissions plus additional user permissions
 
-.. code:: python
-
-    USER_PERMS = {
-        'can_dagrun_clear',
-        'can_run',
-        'can_trigger',
-        'can_add',
-        'can_edit',
-        'can_delete',
-        'can_paused',
-        'can_refresh',
-        'can_success',
-        'muldelete',
-        'set_failed',
-        'set_running',
-        'set_success',
-        'clear',
-        'can_clear',
-    }
+.. literalinclude:: ../airflow/www/security.py
+    :language: python
+    :start-after: [START security_user_perms]
+    :end-before: [END security_user_perms]
 
 
 on User web views which is the same as Viewer web views.
@@ -535,30 +477,20 @@ Op
 ^^
 ``Op`` users have ``User`` permissions plus additional op permissions
 
-.. code:: python
 
-    OP_PERMS = {
-        'can_conf',
-        'can_varimport',
-    }
+.. literalinclude:: ../airflow/www/security.py
+    :language: python
+    :start-after: [START security_op_perms]
+    :end-before: [END security_op_perms]
+
 
 on ``User`` web views plus these additional op web views
 
-.. code:: python
 
-    OP_VMS = {
-        'Admin',
-        'Configurations',
-        'ConfigurationView',
-        'Connections',
-        'ConnectionModelView',
-        'Pools',
-        'PoolModelView',
-        'Variables',
-        'VariableModelView',
-        'XComs',
-        'XComModelView',
-    }
+.. literalinclude:: ..//airflow/www/security.py
+    :language: python
+    :start-after: [START security_op_vms]
+    :end-before: [END security_op_vms]
 
 Custom Roles
 '''''''''''''

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -28,62 +28,11 @@ Example Pipeline definition
 Here is an example of a basic pipeline definition. Do not worry if this looks
 complicated, a line by line explanation follows below.
 
-.. code:: python
+.. literalinclude:: ../airflow/example_dags/example_lineage.py
+    :language: python
+    :start-after: [START tutorial]
+    :end-before: [END tutorial]
 
-    """
-    Code that goes along with the Airflow tutorial located at:
-    https://github.com/apache/airflow/blob/master/airflow/example_dags/tutorial.py
-    """
-    from airflow import DAG
-    from airflow.operators.bash_operator import BashOperator
-    from datetime import datetime, timedelta
-
-
-    default_args = {
-        'owner': 'airflow',
-        'depends_on_past': False,
-        'start_date': datetime(2015, 6, 1),
-        'email': ['airflow@example.com'],
-        'email_on_failure': False,
-        'email_on_retry': False,
-        'retries': 1,
-        'retry_delay': timedelta(minutes=5),
-        # 'queue': 'bash_queue',
-        # 'pool': 'backfill',
-        # 'priority_weight': 10,
-        # 'end_date': datetime(2016, 1, 1),
-    }
-
-    dag = DAG('tutorial', default_args=default_args, schedule_interval=timedelta(days=1))
-
-    # t1, t2 and t3 are examples of tasks created by instantiating operators
-    t1 = BashOperator(
-        task_id='print_date',
-        bash_command='date',
-        dag=dag)
-
-    t2 = BashOperator(
-        task_id='sleep',
-        bash_command='sleep 5',
-        retries=3,
-        dag=dag)
-
-    templated_command = """
-        {% for i in range(5) %}
-            echo "{{ ds }}"
-            echo "{{ macros.ds_add(ds, 7)}}"
-            echo "{{ params.my_param }}"
-        {% endfor %}
-    """
-
-    t3 = BashOperator(
-        task_id='templated',
-        bash_command=templated_command,
-        params={'my_param': 'Parameter I passed in'},
-        dag=dag)
-
-    t2.set_upstream(t1)
-    t3.set_upstream(t1)
 
 
 It's a DAG definition file

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -62,7 +62,8 @@ We'll need the DAG object to instantiate a DAG and BashOperator to operate!
 
 .. literalinclude:: ../airflow/example_dags/tutorial.py
     :language: python
-    :lines: 29-30
+    :start-after: [START tutorial_import_modules]
+    :end-before: [END tutorial_import_modules]
 
 Default Arguments
 -----------------
@@ -73,7 +74,8 @@ of default parameters that we can use when creating tasks.
 
 .. literalinclude:: ../airflow/example_dags/tutorial.py
     :language: python
-    :lines: 34-56
+    :start-after: [START tutorial_default_arguments]
+    :end-before: [END tutorial_default_arguments]
 
 Also, note that you could easily define different sets of arguments that
 would serve different purposes. An example of that would be to have
@@ -90,7 +92,8 @@ define a ``schedule_interval`` of 1 day for the DAG.
 
 .. literalinclude:: ../airflow/example_dags/tutorial.py
     :language: python
-    :lines: 58-63
+    :start-after: [START tutorial_init_dag]
+    :end-before: [END tutorial_init_dag]
 
 Tasks
 -----
@@ -100,7 +103,13 @@ instantiated from an operator is called a constructor. The first argument
 
 .. literalinclude:: ../airflow/example_dags/tutorial.py
     :language: python
-    :lines: 66-71, 82-89
+    :start-after: [START tutorial_task1_without_doc]
+    :end-before: [END tutorial_task1_without_doc]
+
+.. literalinclude:: ../airflow/example_dags/tutorial.py
+    :language: python
+    :start-after: [START tutorial_task2]
+    :end-before: [END tutorial_task2]
 
 Notice how we pass a mix of operator specific arguments (``bash_command``) and
 an argument common to all operators (``retries``) inherited
@@ -136,7 +145,8 @@ stamp").
 
 .. literalinclude:: ../airflow/example_dags/tutorial.py
     :language: python
-    :lines: 90-105
+    :start-after: [START tutorial_task3]
+    :end-before: [END tutorial_task3]
 
 Notice that the ``templated_command`` contains code logic in ``{% %}`` blocks,
 references parameters like ``{{ ds }}``, calls a function as in

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -28,12 +28,19 @@ Example Pipeline definition
 Here is an example of a basic pipeline definition. Do not worry if this looks
 complicated, a line by line explanation follows below.
 
+<<<<<<< HEAD
 .. literalinclude:: ../airflow/example_dags/example_lineage.py
     :language: python
     :start-after: [START tutorial]
     :end-before: [END tutorial]
 
 
+=======
+.. literalinclude:: ../airflow/example_dags/tutorial.py
+    :language: python
+    :start-after: [START tutorial]
+    :end-before: [END tutorial]
+>>>>>>> Extract example DAGs to separate files in doc
 
 It's a DAG definition file
 --------------------------
@@ -60,13 +67,11 @@ Importing Modules
 An Airflow pipeline is just a Python script that happens to define an
 Airflow DAG object. Let's start by importing the libraries we will need.
 
-.. code:: python
+We'll need the DAG object to instantiate a DAG and BashOperator to operate!
 
-    # The DAG object; we'll need this to instantiate a DAG
-    from airflow import DAG
-
-    # Operators; we need this to operate!
-    from airflow.operators.bash_operator import BashOperator
+.. literalinclude:: ../airflow/example_dags/tutorial.py
+    :language: python
+    :lines: 29-30
 
 Default Arguments
 -----------------
@@ -75,27 +80,9 @@ explicitly pass a set of arguments to each task's constructor
 (which would become redundant), or (better!) we can define a dictionary
 of default parameters that we can use when creating tasks.
 
-.. code:: python
-
-    from datetime import datetime, timedelta
-
-    default_args = {
-        'owner': 'airflow',
-        'depends_on_past': False,
-        'start_date': datetime(2015, 6, 1),
-        'email': ['airflow@example.com'],
-        'email_on_failure': False,
-        'email_on_retry': False,
-        'retries': 1,
-        'retry_delay': timedelta(minutes=5),
-        # 'queue': 'bash_queue',
-        # 'pool': 'backfill',
-        # 'priority_weight': 10,
-        # 'end_date': datetime(2016, 1, 1),
-    }
-
-For more information about the BaseOperator's parameters and what they do,
-refer to the :py:class:`airflow.models.BaseOperator` documentation.
+.. literalinclude:: ../airflow/example_dags/tutorial.py
+    :language: python
+    :lines: 34-56
 
 Also, note that you could easily define different sets of arguments that
 would serve different purposes. An example of that would be to have
@@ -110,10 +97,9 @@ that defines the ``dag_id``, which serves as a unique identifier for your DAG.
 We also pass the default argument dictionary that we just defined and
 define a ``schedule_interval`` of 1 day for the DAG.
 
-.. code:: python
-
-    dag = DAG(
-        'tutorial', default_args=default_args, schedule_interval=timedelta(days=1))
+.. literalinclude:: ../airflow/example_dags/tutorial.py
+    :language: python
+    :lines: 58-63
 
 Tasks
 -----
@@ -121,24 +107,18 @@ Tasks are generated when instantiating operator objects. An object
 instantiated from an operator is called a constructor. The first argument
 ``task_id`` acts as a unique identifier for the task.
 
-.. code:: python
-
-    t1 = BashOperator(
-        task_id='print_date',
-        bash_command='date',
-        dag=dag)
-
-    t2 = BashOperator(
-        task_id='sleep',
-        bash_command='sleep 5',
-        retries=3,
-        dag=dag)
+.. literalinclude:: ../airflow/example_dags/tutorial.py
+    :language: python
+    :lines: 66-71, 82-89
 
 Notice how we pass a mix of operator specific arguments (``bash_command``) and
 an argument common to all operators (``retries``) inherited
 from BaseOperator to the operator's constructor. This is simpler than
 passing every argument for every constructor call. Also, notice that in
 the second task we override the ``retries`` parameter with ``3``.
+
+For more information about the BaseOperator's parameters and what they do,
+refer to the :py:class:`airflow.models.BaseOperator` documentation.
 
 The precedence rules for a task are as follows:
 
@@ -153,10 +133,9 @@ Templating with Jinja
 ---------------------
 Airflow leverages the power of
 `Jinja Templating <http://jinja.pocoo.org/docs/dev/>`_  and provides
-the pipeline author
-with a set of built-in parameters and macros. Airflow also provides
-hooks for the pipeline author to define their own parameters, macros and
-templates.
+the pipeline author with a set of built-in parameters and macros. 
+Airflow also provides hooks for the pipeline author to define their 
+own parameters, macros and templates.
 
 This tutorial barely scratches the surface of what you can do with
 templating in Airflow, but the goal of this section is to let you know
@@ -164,21 +143,9 @@ this feature exists, get you familiar with double curly brackets, and
 point to the most common template variable: ``{{ ds }}`` (today's "date
 stamp").
 
-.. code:: python
-
-    templated_command = """
-        {% for i in range(5) %}
-            echo "{{ ds }}"
-            echo "{{ macros.ds_add(ds, 7) }}"
-            echo "{{ params.my_param }}"
-        {% endfor %}
-    """
-
-    t3 = BashOperator(
-        task_id='templated',
-        bash_command=templated_command,
-        params={'my_param': 'Parameter I passed in'},
-        dag=dag)
+.. literalinclude:: ../airflow/example_dags/tutorial.py
+    :language: python
+    :lines: 90-105
 
 Notice that the ``templated_command`` contains code logic in ``{% %}`` blocks,
 references parameters like ``{{ ds }}``, calls a function as in
@@ -253,63 +220,10 @@ Recap
 Alright, so we have a pretty basic DAG. At this point your code should look
 something like this:
 
-.. code:: python
-
-    """
-    Code that goes along with the Airflow tutorial located at:
-    https://github.com/apache/airflow/blob/master/airflow/example_dags/tutorial.py
-    """
-    from airflow import DAG
-    from airflow.operators.bash_operator import BashOperator
-    from datetime import datetime, timedelta
-
-
-    default_args = {
-        'owner': 'airflow',
-        'depends_on_past': False,
-        'start_date': datetime(2015, 6, 1),
-        'email': ['airflow@example.com'],
-        'email_on_failure': False,
-        'email_on_retry': False,
-        'retries': 1,
-        'retry_delay': timedelta(minutes=5),
-        # 'queue': 'bash_queue',
-        # 'pool': 'backfill',
-        # 'priority_weight': 10,
-        # 'end_date': datetime(2016, 1, 1),
-    }
-
-    dag = DAG(
-        'tutorial', default_args=default_args, schedule_interval=timedelta(days=1))
-
-    # t1, t2 and t3 are examples of tasks created by instantiating operators
-    t1 = BashOperator(
-        task_id='print_date',
-        bash_command='date',
-        dag=dag)
-
-    t2 = BashOperator(
-        task_id='sleep',
-        bash_command='sleep 5',
-        retries=3,
-        dag=dag)
-
-    templated_command = """
-        {% for i in range(5) %}
-            echo "{{ ds }}"
-            echo "{{ macros.ds_add(ds, 7)}}"
-            echo "{{ params.my_param }}"
-        {% endfor %}
-    """
-
-    t3 = BashOperator(
-        task_id='templated',
-        bash_command=templated_command,
-        params={'my_param': 'Parameter I passed in'},
-        dag=dag)
-
-    t2.set_upstream(t1)
-    t3.set_upstream(t1)
+.. literalinclude:: ../airflow/example_dags/tutorial.py
+    :language: python
+    :start-after: [START tutorial]
+    :end-before: [END tutorial]
 
 Testing
 --------
@@ -414,8 +328,8 @@ Here's a few things you might want to do next:
 * Take an in-depth tour of the UI - click all the things!
 * Keep reading the docs! Especially the sections on:
 
-    * Command line interface
-    * Operators
-    * Macros
+    * :ref:`command_line_interface`
+    * :ref:`api-reference-operators`
+    * :ref:`macros`
 
 * Write your first pipeline!

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -28,19 +28,10 @@ Example Pipeline definition
 Here is an example of a basic pipeline definition. Do not worry if this looks
 complicated, a line by line explanation follows below.
 
-<<<<<<< HEAD
-.. literalinclude:: ../airflow/example_dags/example_lineage.py
-    :language: python
-    :start-after: [START tutorial]
-    :end-before: [END tutorial]
-
-
-=======
 .. literalinclude:: ../airflow/example_dags/tutorial.py
     :language: python
     :start-after: [START tutorial]
     :end-before: [END tutorial]
->>>>>>> Extract example DAGs to separate files in doc
 
 It's a DAG definition file
 --------------------------

--- a/tests/contrib/minikube/test_kubernetes_dag.py
+++ b/tests/contrib/minikube/test_kubernetes_dag.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import os
+import unittest
+from datetime import datetime
+
+from airflow import models, AirflowException
+
+from subprocess import check_call
+
+try:
+    check_call(["/usr/local/bin/kubectl", "get", "pods"])
+except Exception as e:
+    if os.environ.get('KUBERNETES_VERSION'):
+        raise e
+    else:
+        raise unittest.SkipTest(
+            "Kubernetes integration tests require a minikube cluster;"
+            "Skipping tests {}".format(e)
+        )
+
+AIRFLOW_MAIN_FOLDER = os.path.realpath(
+    os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir, os.pardir, os.pardir)
+)
+
+DEFAULT_DATE = datetime(2015, 1, 1)
+
+CONTRIB_OPERATORS_EXAMPLES_DAG_FOLDER = os.path.join(
+    AIRFLOW_MAIN_FOLDER, "airflow", "contrib", "example_dags"
+)
+
+
+class KubernetesDagTestCase(unittest.TestCase):
+    def test_run_dag(self):
+        dag_id = 'example_kubernetes'
+        dag_folder = CONTRIB_OPERATORS_EXAMPLES_DAG_FOLDER
+        dag_bag = models.DagBag(dag_folder=dag_folder, include_examples=False)
+        dag = dag_bag.get_dag(dag_id)
+        if dag is None:
+            raise AirflowException(
+                "The Dag {} could not be found. It's either an import problem or the dag {} was not "
+                "symlinked to the DAGs folder. The content of the {} folder is {}".format(
+                    dag_id, dag_id + ".py", dag_folder, os.listdir(dag_folder)
+                )
+            )
+        dag.clear(reset_dag_runs=True)
+        dag.run(ignore_first_depends_on_past=True, verbose=True)

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# [START plugins_interface]
 # This is the class you derive to create a plugin
 from airflow.plugins_manager import AirflowPlugin
 
@@ -95,7 +96,7 @@ class AirflowTestPlugin(AirflowPlugin):
     flask_blueprints = [bp]
     appbuilder_views = [v_appbuilder_package]
     appbuilder_menu_items = [appbuilder_mitem]
-
+# [END plugins_interface]
 
 class MockPluginA(AirflowPlugin):
     name = 'plugin-a'

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import os
+import unittest
+try:
+    # noinspection PyProtectedMember
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+from parameterized import parameterized
+
+from airflow import models, AirflowException, example_dags, DAG
+
+
+class ExampleDagsTestCase(unittest.TestCase):
+
+    @parameterized.expand([
+        ("example_bash_operator",),
+        ('example_branch_operator', ),
+        ('example_branch_dop_operator_v3', ),
+        ('example_default_args', ),
+        ('foo_1', ),
+        ('foo_10', ),
+        ('example_http_operator', ),
+        ('example_latest_only', ),
+        ('example_latest_only_with_trigger', ),
+        ('example_lineage', ),
+        ('example_passing_params_via_test_command', ),
+        ('example_python_operator', ),
+        ('example_short_circuit_operator', ),
+        ('example_skip_dag', ),
+        ('example_subdag_operator', ),
+        ('example_trigger_controller', ),
+        ('example_trigger_target_dag', ),
+        ('example_xcom', ),
+    ])
+    def test_run_dag(self, dag_id):
+        dag_id = 'example_default_args'
+        dag_folder = example_dags.__path__[0]
+        dag_bag = models.DagBag(dag_folder=dag_folder, include_examples=False)
+        dag = dag_bag.get_dag(dag_id)
+        if dag is None:
+            raise AirflowException(
+                "The Dag {dag_id} could not be found. It's either an import problem or the dag was not "
+                "symlinked to the DAGs folder. The content of the {dag_folder} folder is {dags_list}".format(
+                     dag_id=dag_id, dag_folder=dag_folder, dags_list=os.listdir(dag_folder)
+                )
+            )
+        dag.clear(reset_dag_runs=True)
+        dag.run(ignore_first_depends_on_past=True, verbose=True)
+
+
+class ExampleDynamicDagTestCase(unittest.TestCase):
+
+    def test_example(self):
+        with mock.patch.dict('sys.modules'):
+            import airflow.example_dags.example_dynamic_dag
+            for i in range(10):
+                dag = getattr(airflow.example_dags.example_dynamic_dag, 'foo_{}'.format(i))
+                self.assertIsInstance(dag, DAG)

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
+import stat
 import unittest
 try:
     # noinspection PyProtectedMember
@@ -35,35 +36,65 @@ from airflow import models, AirflowException, example_dags, DAG
 class ExampleDagsTestCase(unittest.TestCase):
 
     @parameterized.expand([
-        ("example_bash_operator",),
-        ('example_branch_operator', ),
-        ('example_branch_dop_operator_v3', ),
-        ('example_default_args', ),
-        ('foo_1', ),
-        ('foo_10', ),
-        ('example_http_operator', ),
-        ('example_latest_only', ),
-        ('example_latest_only_with_trigger', ),
-        ('example_lineage', ),
-        ('example_passing_params_via_test_command', ),
-        ('example_python_operator', ),
-        ('example_short_circuit_operator', ),
-        ('example_skip_dag', ),
-        ('example_subdag_operator', ),
-        ('example_trigger_controller', ),
-        ('example_trigger_target_dag', ),
-        ('example_xcom', ),
-    ])
-    def test_run_dag(self, dag_id):
-        dag_id = 'example_default_args'
+        # ("example_branch_operator.py", 'example_branch_operator', ),
+        # ('example_branch_dop_operator_3.py', 'example_branch_dop_operator_v3', ),
+        # ('example_default_args.py', 'example_default_args'),
+        # ('example_dynamic_dag.py', 'foo_1', ),
+        # ('example_dynamic_dag.py', 'foo_10', ),
+        # ('example_http_operator.py', 'example_http_operator', ),
+        # ('example_latest_only.py', 'example_latest_only', ),
+        # ('example_latest_only_with_trigger.py', 'example_latest_only_with_trigger', ),
+        # ('example_lineage.py', 'example_lineage', ),
+        # ('example_passing_params_via_test_command.py', 'example_passing_params_via_test_command', ),
+        # ('example_python_operator.py','example_python_operator', ),
+        # ('example_short_circuit_operator.py','example_short_circuit_operator', ),
+        # ('example_skip_dag.py', 'example_skip_dag', ),
+        # ('example_subdag_operator.py', 'example_subdag_operator', ),
+        ('example_trigger_controller_dag.py', 'example_trigger_controller', ),
+        # ('example_trigger_target_dag.py', 'example_trigger_target_dag', ),
+        # ("example_xcom.py", 'example_xcom', ),
+    ], name_func=lambda func, num, p: "{}_{}".format(func.__name__, p.args[0]))
+    def test_run_dag(self, filename, dag_id):
         dag_folder = example_dags.__path__[0]
-        dag_bag = models.DagBag(dag_folder=dag_folder, include_examples=False)
+        dag_bag = models.DagBag(dag_folder=os.path.join(dag_folder, filename), include_examples=False)
         dag = dag_bag.get_dag(dag_id)
         if dag is None:
             raise AirflowException(
                 "The Dag {dag_id} could not be found. It's either an import problem or the dag was not "
                 "symlinked to the DAGs folder. The content of the {dag_folder} folder is {dags_list}".format(
                      dag_id=dag_id, dag_folder=dag_folder, dags_list=os.listdir(dag_folder)
+                )
+            )
+        dag.clear(reset_dag_runs=True)
+        dag.run(ignore_first_depends_on_past=True, verbose=True)
+
+
+class ExampleBashOperatorTestCase(unittest.TestCase):
+    SHELL_SCRIPT_PATH = "/tmp/test.sh"
+
+    @classmethod
+    def setUpClass(cls):
+        with open(cls.SHELL_SCRIPT_PATH, "w") as file:
+            file.write("#!/usr/bin/env bash\n")
+            file.write("export | grep EXECUTION_DATE")
+        os.chmod(cls.SHELL_SCRIPT_PATH, stat.S_IXGRP | stat.S_IXOTH | stat.S_IEXEC)
+
+    # @classmethod
+    # def tearDownClass(cls):
+    #     if os.path.exists(cls.SHELL_SCRIPT_PATH):
+    #         os.remove(cls.SHELL_SCRIPT_PATH)
+
+    def test_run_dag(self):
+        filename = "example_bash_operator.py"
+        dag_id = 'example_bash_operator'
+        dag_folder = example_dags.__path__[0]
+        dag_bag = models.DagBag(dag_folder=os.path.join(dag_folder, filename), include_examples=False)
+        dag = dag_bag.get_dag(dag_id)
+        if dag is None:
+            raise AirflowException(
+                "The Dag {dag_id} could not be found. It's either an import problem or the dag was not "
+                "symlinked to the DAGs folder. The content of the {dag_folder} folder is {dags_list}".format(
+                    dag_id=dag_id, dag_folder=dag_folder, dags_list=os.listdir(dag_folder)
                 )
             )
         dag.clear(reset_dag_runs=True)

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -36,9 +36,14 @@ from airflow import models, AirflowException, example_dags, DAG
 class ExampleDagsTestCase(unittest.TestCase):
 
     @parameterized.expand([
+        # ("subdags/main_dag.py", "parent_dag", ),
+        # ("subdags/subdag.py", "parent_dag.child_dag", ),
+        # ("example_bash_operator.py", 'example_bash_operator', ),
         # ("example_branch_operator.py", 'example_branch_operator', ),
         # ('example_branch_dop_operator_3.py', 'example_branch_dop_operator_v3', ),
+        # ("example_branch_operator.py", 'example_branch_operator', ),
         # ('example_default_args.py', 'example_default_args'),
+        # ('example_documentation.py', 'example_documentation', ),
         # ('example_dynamic_dag.py', 'foo_1', ),
         # ('example_dynamic_dag.py', 'foo_10', ),
         # ('example_http_operator.py', 'example_http_operator', ),
@@ -53,6 +58,8 @@ class ExampleDagsTestCase(unittest.TestCase):
         ('example_trigger_controller_dag.py', 'example_trigger_controller', ),
         # ('example_trigger_target_dag.py', 'example_trigger_target_dag', ),
         # ("example_xcom.py", 'example_xcom', ),
+        # ('test_utils.py', 'test_utils', ),
+        # ('tutorial.py', 'tutorial', )
     ], name_func=lambda func, num, p: "{}_{}".format(func.__name__, p.args[0]))
     def test_run_dag(self, filename, dag_id):
         dag_folder = example_dags.__path__[0]

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -62,7 +62,9 @@ class ExampleDagsTestCase(unittest.TestCase):
             raise AirflowException(
                 "The Dag {dag_id} could not be found. It's either an import problem or the dag was not "
                 "symlinked to the DAGs folder. The content of the {dag_folder} folder is {dags_list}".format(
-                     dag_id=dag_id, dag_folder=dag_folder, dags_list=os.listdir(dag_folder)
+                    dag_id=dag_id,
+                    dag_folder=dag_folder,
+                    dags_list=os.listdir(dag_folder)
                 )
             )
         dag.clear(reset_dag_runs=True)

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -16,7 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 from datetime import datetime
 
 from bs4 import BeautifulSoup
@@ -25,6 +24,7 @@ import six
 from six.moves.urllib.parse import parse_qs
 
 from airflow.www import utils
+from airflow.www.utils import render_attrs
 
 if six.PY2:
     # Need `assertRegex` back-ported from unittest2
@@ -34,6 +34,7 @@ else:
 
 
 class UtilsTest(unittest.TestCase):
+
     def test_empty_variable_should_not_be_hidden(self):
         self.assertFalse(utils.should_hide_value_for_key(""))
         self.assertFalse(utils.should_hide_value_for_key(None))
@@ -250,3 +251,15 @@ class AttrRendererTest(unittest.TestCase):
     def test_markdown_none(self):
         rendered = self.attr_renderer["python_callable"](None)
         self.assertEqual("", rendered)
+
+    def test_render_attrs_for_task(self):
+        from airflow.example_dags import example_documentation
+        attrs = render_attrs(example_documentation.t)
+        self.assertEquals(attrs['doc_md'], '<div class="rich_doc"><pre><code>#Title"\n'
+                                           "Here's a [url](www.airbnb.com)\n"
+                                           '</code></pre></div>')
+
+    def test_render_attrs_for_dag(self):
+        from airflow.example_dags import example_documentation
+        attrs = render_attrs(example_documentation.dag)
+        self.assertEquals(attrs['doc_md'], '<div class="rich_doc"><h3>My great DAG</h3></div>')


### PR DESCRIPTION
By extracting example python script, we could have unittest on them and make sure correction easily.
The example dags extracted in following documentations:
1. tutorial
2. concepts
3. scheduler
4. lineage

AIRFLOW-4003

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
