### PR TITLE
[AIRFLOW-4807] Make GCS operators Pylint compatible

### DIFF
--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -17,12 +17,16 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+"""
+This module contains a Google Cloud Storage hook.
+"""
+
 import gzip as gz
 import os
 import shutil
 
-from google.cloud import storage
 from urllib.parse import urlparse
+from google.cloud import storage
 
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 from airflow.exceptions import AirflowException
@@ -72,6 +76,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         """
         destination_bucket = destination_bucket or source_bucket
         destination_object = destination_object or source_object
+
         if source_bucket == destination_bucket and \
                 source_object == destination_object:
 
@@ -289,11 +294,11 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         bucket = client.get_bucket(bucket_name)
 
         ids = []
-        pageToken = None
+        page_token = None
         while True:
             blobs = bucket.list_blobs(
                 max_results=max_results,
-                page_token=pageToken,
+                page_token=page_token,
                 prefix=prefix,
                 delimiter=delimiter,
                 versions=versions
@@ -309,8 +314,8 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
             else:
                 ids += blob_names
 
-            pageToken = blobs.next_page_token
-            if pageToken is None:
+            page_token = blobs.next_page_token
+            if page_token is None:
                 # empty next page token
                 break
         return ids
@@ -437,7 +442,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
 
         for item in bucket_resource:
             if item != "name":
-                bucket._patch_property(name=item, value=resource[item])
+                bucket._patch_property(name=item, value=resource[item])  # pylint: disable=protected-access
 
         bucket.storage_class = storage_class
         bucket.labels = labels or {}
@@ -531,7 +536,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         :type destination_object: str
         """
 
-        if not source_objects or not len(source_objects):
+        if not source_objects:
             raise ValueError('source_objects cannot be empty.')
 
         if not bucket_name or not destination_object:

--- a/airflow/contrib/operators/gcs_acl_operator.py
+++ b/airflow/contrib/operators/gcs_acl_operator.py
@@ -16,6 +16,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+This module contains Google Cloud Storage ACL entry operator.
+"""
 
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.models import BaseOperator
@@ -90,9 +93,6 @@ class GoogleCloudStorageObjectCreateAclEntryOperator(BaseOperator):
     :param role: The access permission for the entity.
         Acceptable values are: "OWNER", "READER".
     :type role: str
-    :param generation: (Optional) If present, selects a specific revision of this object
-        (as opposed to the latest version, the default).
-    :type generation: str
     :param user_project: (Optional) The project to be billed for this request.
         Required for Requester Pays buckets.
     :type user_project: str
@@ -111,7 +111,6 @@ class GoogleCloudStorageObjectCreateAclEntryOperator(BaseOperator):
                  object_name,
                  entity,
                  role,
-                 generation=None,
                  user_project=None,
                  google_cloud_storage_conn_id='google_cloud_default',
                  *args, **kwargs):
@@ -121,7 +120,6 @@ class GoogleCloudStorageObjectCreateAclEntryOperator(BaseOperator):
         self.object_name = object_name
         self.entity = entity
         self.role = role
-        self.generation = generation
         self.user_project = user_project
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
 
@@ -130,5 +128,4 @@ class GoogleCloudStorageObjectCreateAclEntryOperator(BaseOperator):
             google_cloud_storage_conn_id=self.google_cloud_storage_conn_id
         )
         hook.insert_object_acl(bucket_name=self.bucket, object_name=self.object_name,
-                               entity=self.entity, role=self.role,
-                               generation=self.generation, user_project=self.user_project)
+                               entity=self.entity, role=self.role, user_project=self.user_project)

--- a/airflow/contrib/operators/gcs_delete_operator.py
+++ b/airflow/contrib/operators/gcs_delete_operator.py
@@ -16,12 +16,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+This module contains Google Cloud Storage delete operator.
+"""
+
+from typing import Optional, Iterable
 
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
-
-from typing import Optional, Iterable
 
 
 class GoogleCloudStorageDeleteOperator(BaseOperator):

--- a/airflow/contrib/operators/gcs_list_operator.py
+++ b/airflow/contrib/operators/gcs_list_operator.py
@@ -16,6 +16,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+This module contains a Google Cloud Storage list operator.
+"""
 
 from typing import Iterable
 
@@ -61,6 +64,7 @@ class GoogleCloudStorageListOperator(BaseOperator):
             )
     """
     template_fields = ('bucket', 'prefix', 'delimiter')  # type: Iterable[str]
+
     ui_color = '#f0eee4'
 
     @apply_defaults

--- a/airflow/contrib/operators/gcs_operator.py
+++ b/airflow/contrib/operators/gcs_operator.py
@@ -16,6 +16,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+This module contains a Google Cloud Storage Bucket operator.
+"""
 
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.models import BaseOperator
@@ -82,7 +85,6 @@ class GoogleCloudStorageCreateBucketOperator(BaseOperator):
             google_cloud_storage_conn_id='airflow-service-account'
         )
     """
-
     template_fields = ('bucket_name', 'storage_class',
                        'location', 'project_id')
     ui_color = '#f0eee4'

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -16,15 +16,20 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+This module contains a Google Cloud Storage to BigQuery operator.
+"""
 
 import json
 
+from airflow import AirflowException
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.contrib.hooks.bigquery_hook import BigQueryHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
 
+# pylint: disable=too-many-instance-attributes
 class GoogleCloudStorageToBigQueryOperator(BaseOperator):
     """
     Loads files from Google cloud storage into BigQuery.
@@ -137,6 +142,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
     template_ext = ('.sql',)
     ui_color = '#f0eee4'
 
+    # pylint: disable=too-many-locals,too-many-arguments
     @apply_defaults
     def __init__(self,
                  bucket,
@@ -218,8 +224,8 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                     self.bucket,
                     self.schema_object).decode("utf-8"))
             elif self.schema_object is None and self.autodetect is False:
-                raise ValueError('At least one of `schema_fields`, `schema_object`, '
-                                 'or `autodetect` must be passed.')
+                raise AirflowException('At least one of `schema_fields`, '
+                                       '`schema_object`, or `autodetect` must be passed.')
             else:
                 schema_fields = None
 
@@ -278,4 +284,3 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                 'Loaded BQ data with max %s.%s=%s',
                 self.destination_project_dataset_table, self.max_id_key, max_id
             )
-            return max_id

--- a/airflow/contrib/operators/gcs_to_gcs.py
+++ b/airflow/contrib/operators/gcs_to_gcs.py
@@ -16,6 +16,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+This module contains a Google Cloud Storage operator.
+"""
 
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.models import BaseOperator
@@ -183,7 +186,6 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
                                      source_object,
                                      self.last_modified_time):
                 self.log.debug("Object has been modified after %s ", self.last_modified_time)
-                pass
             else:
                 return
 

--- a/airflow/contrib/operators/gcs_to_gcs_transfer_operator.py
+++ b/airflow/contrib/operators/gcs_to_gcs_transfer_operator.py
@@ -16,8 +16,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+This module is deprecated. Please use `airflow.contrib.operators.gcp_transfer_operator`.
+"""
+
 import warnings
 
+# pylint: disable=unused-import
 from airflow.contrib.operators.gcp_transfer_operator import (  # noqa
     GoogleCloudStorageToGoogleCloudStorageTransferOperator,
 )

--- a/airflow/contrib/operators/gcs_to_s3.py
+++ b/airflow/contrib/operators/gcs_to_s3.py
@@ -16,6 +16,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+This module contains Google Cloud Storage to S3 operator.
+"""
 
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.contrib.operators.gcs_list_operator import GoogleCloudStorageListOperator
@@ -57,6 +60,7 @@ class GoogleCloudStorageToS3Operator(GoogleCloudStorageListOperator):
         - ``path/to/cert/bundle.pem``: A filename of the CA cert bundle to uses.
                  You can specify this argument if you want to use a different
                  CA cert bundle than the one used by botocore.
+
     :type dest_verify: bool or str
     :param replace: Whether or not to verify the existence of the files in the
         destination bucket.

--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -91,7 +91,6 @@
 ./airflow/contrib/hooks/gcp_translate_hook.py
 ./airflow/contrib/hooks/gcp_video_intelligence_hook.py
 ./airflow/contrib/hooks/gcp_vision_hook.py
-./airflow/contrib/hooks/gcs_hook.py
 ./airflow/contrib/hooks/grpc_hook.py
 ./airflow/contrib/hooks/imap_hook.py
 ./airflow/contrib/hooks/jenkins_hook.py
@@ -162,15 +161,6 @@
 ./airflow/contrib/operators/gcp_translate_speech_operator.py
 ./airflow/contrib/operators/gcp_video_intelligence_operator.py
 ./airflow/contrib/operators/gcp_vision_operator.py
-./airflow/contrib/operators/gcs_acl_operator.py
-./airflow/contrib/operators/gcs_delete_operator.py
-./airflow/contrib/operators/gcs_download_operator.py
-./airflow/contrib/operators/gcs_list_operator.py
-./airflow/contrib/operators/gcs_operator.py
-./airflow/contrib/operators/gcs_to_bq.py
-./airflow/contrib/operators/gcs_to_gcs.py
-./airflow/contrib/operators/gcs_to_gcs_transfer_operator.py
-./airflow/contrib/operators/gcs_to_s3.py
 ./airflow/contrib/operators/grpc_operator.py
 ./airflow/contrib/operators/hipchat_operator.py
 ./airflow/contrib/operators/hive_to_dynamodb.py
@@ -238,7 +228,6 @@
 ./airflow/contrib/sensors/file_sensor.py
 ./airflow/contrib/sensors/ftp_sensor.py
 ./airflow/contrib/sensors/gcp_transfer_sensor.py
-./airflow/contrib/sensors/gcs_sensor.py
 ./airflow/contrib/sensors/hdfs_sensor.py
 ./airflow/contrib/sensors/imap_attachment_sensor.py
 ./airflow/contrib/sensors/jira_sensor.py
@@ -369,6 +358,7 @@
 ./airflow/migrations/versions/e3a246e0dc1_current_schema.py
 ./airflow/migrations/versions/f23433877c24_fix_mysql_not_null_constraint.py
 ./airflow/migrations/versions/f2ca10b85618_add_dag_stats_table.py
+./airflow/migrations/versions/004c1210f153_increase_queue_name_size_limit.py
 ./airflow/models/__init__.py
 ./airflow/models/base.py
 ./airflow/models/baseoperator.py

--- a/tests/contrib/operators/test_gcs_acl_operator.py
+++ b/tests/contrib/operators/test_gcs_acl_operator.py
@@ -50,7 +50,6 @@ class GoogleCloudStorageAclTest(unittest.TestCase):
             object_name="test-object",
             entity="test-entity",
             role="test-role",
-            generation="test-generation",
             user_project="test-user-project",
             task_id="id"
         )
@@ -60,6 +59,5 @@ class GoogleCloudStorageAclTest(unittest.TestCase):
             object_name="test-object",
             entity="test-entity",
             role="test-role",
-            generation="test-generation",
             user_project="test-user-project"
         )

--- a/tests/contrib/operators/test_gcs_download_operator.py
+++ b/tests/contrib/operators/test_gcs_download_operator.py
@@ -35,7 +35,7 @@ class GoogleCloudStorageDownloadOperatorTest(unittest.TestCase):
     def test_execute(self, mock_hook):
         operator = GoogleCloudStorageDownloadOperator(task_id=TASK_ID,
                                                       bucket=TEST_BUCKET,
-                                                      object=TEST_OBJECT,
+                                                      object_name=TEST_OBJECT,
                                                       filename=LOCAL_FILE_PATH)
 
         operator.execute(None)

--- a/tests/contrib/sensors/test_gcs_upload_session_sensor.py
+++ b/tests/contrib/sensors/test_gcs_upload_session_sensor.py
@@ -21,7 +21,8 @@
 import unittest
 import unittest.mock as mock
 from datetime import datetime, timedelta
-from airflow import configuration
+
+from airflow import configuration, AirflowException
 from airflow import models, DAG
 from airflow.contrib.sensors import gcs_sensor
 from airflow.settings import Session
@@ -85,7 +86,7 @@ class GoogleCloudStorageUploadSessionCompleteSensorTest(unittest.TestCase):
     @mock.patch('airflow.contrib.sensors.gcs_sensor.get_time', mock_time)
     def test_files_deleted_between_pokes_throw_error(self):
         self.sensor.is_bucket_updated(2)
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AirflowException):
             self.sensor.is_bucket_updated(1)
 
     @mock.patch('airflow.contrib.sensors.gcs_sensor.get_time', mock_time)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
