### PR TITLE
[AIRFLOW-XXXX] Fix pylint attr defined outside init in tests

### DIFF
--- a/tests/contrib/hooks/test_azure_cosmos_hook.py
+++ b/tests/contrib/hooks/test_azure_cosmos_hook.py
@@ -57,7 +57,7 @@ class TestAzureCosmosDbHook(unittest.TestCase):
 
     @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
     def test_create_database(self, cosmos_mock):
-        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
+        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
         self.cosmos.create_database(self.test_database_name)
         expected_calls = [mock.call().CreateDatabase({'id': self.test_database_name})]
         cosmos_mock.assert_any_call(self.test_end_point, {'masterKey': self.test_master_key})
@@ -65,17 +65,17 @@ class TestAzureCosmosDbHook(unittest.TestCase):
 
     @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
     def test_create_database_exception(self, cosmos_mock):
-        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
+        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
         self.assertRaises(AirflowException, self.cosmos.create_database, None)
 
     @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
     def test_create_container_exception(self, cosmos_mock):
-        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
+        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
         self.assertRaises(AirflowException, self.cosmos.create_collection, None)
 
     @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
     def test_create_container(self, cosmos_mock):
-        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
+        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
         self.cosmos.create_collection(self.test_collection_name, self.test_database_name)
         expected_calls = [mock.call().CreateContainer(
             'dbs/test_database_name',
@@ -85,7 +85,7 @@ class TestAzureCosmosDbHook(unittest.TestCase):
 
     @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
     def test_create_container_default(self, cosmos_mock):
-        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
+        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
         self.cosmos.create_collection(self.test_collection_name)
         expected_calls = [mock.call().CreateContainer(
             'dbs/test_database_default',
@@ -97,7 +97,7 @@ class TestAzureCosmosDbHook(unittest.TestCase):
     def test_upsert_document_default(self, cosmos_mock):
         test_id = str(uuid.uuid4())
         cosmos_mock.return_value.CreateItem.return_value = {'id': test_id}
-        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
+        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
         returned_item = self.cosmos.upsert_document({'id': test_id})
         expected_calls = [mock.call().CreateItem(
             'dbs/' + self.test_database_default + '/colls/' + self.test_collection_default,
@@ -111,7 +111,7 @@ class TestAzureCosmosDbHook(unittest.TestCase):
     def test_upsert_document(self, cosmos_mock):
         test_id = str(uuid.uuid4())
         cosmos_mock.return_value.CreateItem.return_value = {'id': test_id}
-        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
+        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
         returned_item = self.cosmos.upsert_document(
             {'data1': 'somedata'},
             database_name=self.test_database_name,
@@ -137,7 +137,7 @@ class TestAzureCosmosDbHook(unittest.TestCase):
             {'id': test_id2, 'data': 'data2'},
             {'id': test_id3, 'data': 'data3'}]
 
-        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
+        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
         returned_item = self.cosmos.insert_documents(documents)
         expected_calls = [
             mock.call().CreateItem(
@@ -155,7 +155,7 @@ class TestAzureCosmosDbHook(unittest.TestCase):
 
     @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
     def test_delete_database(self, cosmos_mock):
-        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
+        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
         self.cosmos.delete_database(self.test_database_name)
         expected_calls = [mock.call().DeleteDatabase('dbs/test_database_name')]
         cosmos_mock.assert_any_call(self.test_end_point, {'masterKey': self.test_master_key})
@@ -163,17 +163,17 @@ class TestAzureCosmosDbHook(unittest.TestCase):
 
     @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
     def test_delete_database_exception(self, cosmos_mock):
-        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
+        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
         self.assertRaises(AirflowException, self.cosmos.delete_database, None)
 
     @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
     def test_delete_container_exception(self, cosmos_mock):
-        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
+        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
         self.assertRaises(AirflowException, self.cosmos.delete_collection, None)
 
     @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
     def test_delete_container(self, cosmos_mock):
-        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
+        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
         self.cosmos.delete_collection(self.test_collection_name, self.test_database_name)
         expected_calls = [mock.call().DeleteContainer('dbs/test_database_name/colls/test_collection_name')]
         cosmos_mock.assert_any_call(self.test_end_point, {'masterKey': self.test_master_key})
@@ -181,7 +181,7 @@ class TestAzureCosmosDbHook(unittest.TestCase):
 
     @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
     def test_delete_container_default(self, cosmos_mock):
-        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
+        self.cosmos = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
         self.cosmos.delete_collection(self.test_collection_name)
         expected_calls = [mock.call().DeleteContainer('dbs/test_database_default/colls/test_collection_name')]
         cosmos_mock.assert_any_call(self.test_end_point, {'masterKey': self.test_master_key})

--- a/tests/contrib/operators/test_azure_cosmos_insertdocument_operator.py
+++ b/tests/contrib/operators/test_azure_cosmos_insertdocument_operator.py
@@ -54,7 +54,7 @@ class TestAzureCosmosDbHook(unittest.TestCase):
     def test_insert_document(self, cosmos_mock):
         test_id = str(uuid.uuid4())
         cosmos_mock.return_value.CreateItem.return_value = {'id': test_id}
-        self.cosmos = AzureCosmosInsertDocumentOperator(
+        self.cosmos = AzureCosmosInsertDocumentOperator(  # pylint:disable=attribute-defined-outside-init
             database_name=self.test_database_name,
             collection_name=self.test_collection_name,
             document={'id': test_id, 'data': 'sometestdata'},

--- a/tests/contrib/operators/test_emr_add_steps_operator.py
+++ b/tests/contrib/operators/test_emr_add_steps_operator.py
@@ -96,7 +96,7 @@ class TestEmrAddStepsOperator(unittest.TestCase):
         # Mock out the emr_client creator
         emr_session_mock = MagicMock()
         emr_session_mock.client.return_value = self.emr_client_mock
-        self.boto3_session_mock = MagicMock(return_value=emr_session_mock)
+        self.boto3_session_mock = MagicMock(return_value=emr_session_mock)  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
 
         with patch('boto3.session.Session', self.boto3_session_mock):
             self.assertEqual(self.operator.execute(None), ['s-2LH3R5GW3A53T'])

--- a/tests/contrib/operators/test_emr_create_job_flow_operator.py
+++ b/tests/contrib/operators/test_emr_create_job_flow_operator.py
@@ -107,7 +107,7 @@ class TestEmrCreateJobFlowOperator(unittest.TestCase):
         # Mock out the emr_client creator
         emr_session_mock = MagicMock()
         emr_session_mock.client.return_value = self.emr_client_mock
-        self.boto3_session_mock = MagicMock(return_value=emr_session_mock)
+        self.boto3_session_mock = MagicMock(return_value=emr_session_mock)  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
 
         with patch('boto3.session.Session', self.boto3_session_mock):
             self.assertEqual(self.operator.execute(None), 'j-8989898989')

--- a/tests/contrib/sensors/test_emr_step_sensor.py
+++ b/tests/contrib/sensors/test_emr_step_sensor.py
@@ -213,7 +213,7 @@ class TestEmrStepSensor(unittest.TestCase):
             DESCRIBE_JOB_STEP_CANCELLED_RETURN
         ]
 
-        self.boto3_client_mock = MagicMock(return_value=self.emr_client_mock)
+        self.boto3_client_mock = MagicMock(return_value=self.emr_client_mock)  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
 
         with patch('boto3.session.Session', self.boto3_session_mock):
             self.assertRaises(AirflowException, self.sensor.execute, None)
@@ -224,7 +224,7 @@ class TestEmrStepSensor(unittest.TestCase):
             DESCRIBE_JOB_STEP_FAILED_RETURN
         ]
 
-        self.boto3_client_mock = MagicMock(return_value=self.emr_client_mock)
+        self.boto3_client_mock = MagicMock(return_value=self.emr_client_mock)  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
 
         with patch('boto3.session.Session', self.boto3_session_mock):
             self.assertRaises(AirflowException, self.sensor.execute, None)
@@ -235,7 +235,7 @@ class TestEmrStepSensor(unittest.TestCase):
             DESCRIBE_JOB_STEP_INTERRUPTED_RETURN
         ]
 
-        self.boto3_client_mock = MagicMock(return_value=self.emr_client_mock)
+        self.boto3_client_mock = MagicMock(return_value=self.emr_client_mock)  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
 
         with patch('boto3.session.Session', self.boto3_session_mock):
             self.assertRaises(AirflowException, self.sensor.execute, None)

--- a/tests/contrib/sensors/test_redis_pub_sub_sensor.py
+++ b/tests/contrib/sensors/test_redis_pub_sub_sensor.py
@@ -49,7 +49,7 @@ class TestRedisPubSubSensor(unittest.TestCase):
             redis_conn_id='redis_default'
         )
 
-        self.mock_redis_conn = mock_redis_conn
+        self.mock_redis_conn = mock_redis_conn  # pylint:disable=attribute-defined-outside-init
         self.mock_redis_conn().pubsub().get_message.return_value = \
             {'type': 'message', 'channel': b'test', 'data': b'd1'}
 
@@ -69,7 +69,7 @@ class TestRedisPubSubSensor(unittest.TestCase):
             channels='test',
             redis_conn_id='redis_default'
         )
-        self.mock_redis_conn = mock_redis_conn
+        self.mock_redis_conn = mock_redis_conn  # pylint:disable=attribute-defined-outside-init
         self.mock_redis_conn().pubsub().get_message.return_value = \
             {'type': 'subscribe', 'channel': b'test', 'data': b'd1'}
 

--- a/tests/hooks/test_pig_hook.py
+++ b/tests/hooks/test_pig_hook.py
@@ -104,7 +104,7 @@ class TestPigCliHook(unittest.TestCase):
     def test_kill_no_sp(self):
         sp_mock = mock.Mock()
         hook = self.pig_hook()
-        hook.sp = sp_mock
+        hook.sp = sp_mock  # pylint:disable=attribute-defined-outside-init
 
         hook.kill()
         self.assertFalse(sp_mock.kill.called)
@@ -114,7 +114,7 @@ class TestPigCliHook(unittest.TestCase):
         sp_mock.poll.return_value = 0
 
         hook = self.pig_hook()
-        hook.sp = sp_mock
+        hook.sp = sp_mock  # pylint:disable=attribute-defined-outside-init
 
         hook.kill()
         self.assertFalse(sp_mock.kill.called)
@@ -124,7 +124,7 @@ class TestPigCliHook(unittest.TestCase):
         sp_mock.poll.return_value = None
 
         hook = self.pig_hook()
-        hook.sp = sp_mock
+        hook.sp = sp_mock  # pylint:disable=attribute-defined-outside-init
 
         hook.kill()
         self.assertTrue(sp_mock.kill.called)

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -996,20 +996,20 @@ class TaskInstanceTest(unittest.TestCase):
     def test_success_callbak_no_race_condition(self):
         class CallbackWrapper:
             def wrap_task_instance(self, ti):
-                self.task_id = ti.task_id
-                self.dag_id = ti.dag_id
-                self.execution_date = ti.execution_date
-                self.task_state_in_callback = ""
-                self.callback_ran = False
+                self.task_id = ti.task_id  # pylint:disable=attribute-defined-outside-init
+                self.dag_id = ti.dag_id  # pylint:disable=attribute-defined-outside-init
+                self.execution_date = ti.execution_date  # pylint:disable=attribute-defined-outside-init
+                self.task_state_in_callback = ""  # pylint:disable=attribute-defined-outside-init
+                self.callback_ran = False  # pylint:disable=attribute-defined-outside-init
 
             def success_handler(self, context):
-                self.callback_ran = True
+                self.callback_ran = True  # pylint:disable=attribute-defined-outside-init
                 session = settings.Session()
                 temp_instance = session.query(TI).filter(
                     TI.task_id == self.task_id).filter(
                     TI.dag_id == self.dag_id).filter(
                     TI.execution_date == self.execution_date).one()
-                self.task_state_in_callback = temp_instance.state
+                self.task_state_in_callback = temp_instance.state  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
 
         cw = CallbackWrapper()
         dag = DAG('test_success_callbak_no_race_condition', start_date=DEFAULT_DATE,

--- a/tests/operators/test_bash_operator.py
+++ b/tests/operators/test_bash_operator.py
@@ -42,7 +42,7 @@ class BashOperatorTest(unittest.TestCase):
         now = datetime.utcnow()
         now = now.replace(tzinfo=timezone.utc)
 
-        self.dag = DAG(
+        self.dag = DAG(  # pylint:disable=attribute-defined-outside-init
             dag_id='bash_op_test', default_args={
                 'owner': 'airflow',
                 'retries': 100,

--- a/tests/operators/test_python_operator.py
+++ b/tests/operators/test_python_operator.py
@@ -271,7 +271,7 @@ class BranchOperatorTest(unittest.TestCase):
 
     def test_without_dag_run(self):
         """This checks the defensive against non existent tasks in a dag run"""
-        self.branch_op = BranchPythonOperator(task_id='make_choice',
+        self.branch_op = BranchPythonOperator(task_id='make_choice',  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
                                               dag=self.dag,
                                               python_callable=lambda: 'branch_1')
         self.branch_1.set_upstream(self.branch_op)
@@ -299,12 +299,12 @@ class BranchOperatorTest(unittest.TestCase):
 
     def test_branch_list_without_dag_run(self):
         """This checks if the BranchPythonOperator supports branching off to a list of tasks."""
-        self.branch_op = BranchPythonOperator(task_id='make_choice',
+        self.branch_op = BranchPythonOperator(task_id='make_choice',  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
                                               dag=self.dag,
                                               python_callable=lambda: ['branch_1', 'branch_2'])
         self.branch_1.set_upstream(self.branch_op)
         self.branch_2.set_upstream(self.branch_op)
-        self.branch_3 = DummyOperator(task_id='branch_3', dag=self.dag)
+        self.branch_3 = DummyOperator(task_id='branch_3', dag=self.dag)  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
         self.branch_3.set_upstream(self.branch_op)
         self.dag.clear()
 
@@ -330,7 +330,7 @@ class BranchOperatorTest(unittest.TestCase):
                     raise Exception
 
     def test_with_dag_run(self):
-        self.branch_op = BranchPythonOperator(task_id='make_choice',
+        self.branch_op = BranchPythonOperator(task_id='make_choice',  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
                                               dag=self.dag,
                                               python_callable=lambda: 'branch_1')
 
@@ -359,7 +359,7 @@ class BranchOperatorTest(unittest.TestCase):
                 raise Exception
 
     def test_with_skip_in_branch_downstream_dependencies(self):
-        self.branch_op = BranchPythonOperator(task_id='make_choice',
+        self.branch_op = BranchPythonOperator(task_id='make_choice',  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
                                               dag=self.dag,
                                               python_callable=lambda: 'branch_1')
 
@@ -388,7 +388,7 @@ class BranchOperatorTest(unittest.TestCase):
                 raise Exception
 
     def test_with_skip_in_branch_downstream_dependencies2(self):
-        self.branch_op = BranchPythonOperator(task_id='make_choice',
+        self.branch_op = BranchPythonOperator(task_id='make_choice',  # pylint:disable=attribute-defined-outside-init,line-too-long  # noqa
                                               dag=self.dag,
                                               python_callable=lambda: 'branch_2')
 

--- a/tests/test_utils/decorators.py
+++ b/tests/test_utils/decorators.py
@@ -32,7 +32,7 @@ class mock_conf_get(ContextDecorator):
         self.mock_return_value = mock_return_value
 
     def __enter__(self):
-        self.old_conf_get = conf.getint
+        self.old_conf_get = conf.getint  # pylint:disable=attribute-defined-outside-init
 
         def side_effect(section, key):
             if section == self.mock_section and key == self.mock_key:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
