### PR TITLE
[AIRFLOW-XXXX] Fix pylint no value for parameter in tests

### DIFF
--- a/airflow/contrib/example_dags/example_pubsub_flow.py
+++ b/airflow/contrib/example_dags/example_pubsub_flow.py
@@ -70,17 +70,17 @@ echo_template = '''
 
 with DAG('pubsub-end-to-end', default_args=default_args,
          schedule_interval=datetime.timedelta(days=1)) as dag:
-    t1 = PubSubTopicCreateOperator(task_id='create-topic')
-    t2 = PubSubSubscriptionCreateOperator(
+    t1 = PubSubTopicCreateOperator(task_id='create-topic')  # pylint:disable=no-value-for-parameter
+    t2 = PubSubSubscriptionCreateOperator(  # pylint:disable=no-value-for-parameter
         task_id='create-subscription', topic_project=project,
         subscription=subscription)
-    t3 = PubSubPublishOperator(
+    t3 = PubSubPublishOperator(  # pylint:disable=no-value-for-parameter
         task_id='publish-messages', messages=messages)
-    t4 = PubSubPullSensor(task_id='pull-messages', ack_messages=True)
+    t4 = PubSubPullSensor(task_id='pull-messages', ack_messages=True)  # pylint:disable=no-value-for-parameter,line-too-long  # noqa
     t5 = BashOperator(task_id='echo-pulled-messages',
                       bash_command=echo_template)
-    t6 = PubSubSubscriptionDeleteOperator(task_id='delete-subscription')
-    t7 = PubSubTopicDeleteOperator(task_id='delete-topic')
+    t6 = PubSubSubscriptionDeleteOperator(task_id='delete-subscription')  # pylint:disable=no-value-for-parameter,line-too-long  # noqa
+    t7 = PubSubTopicDeleteOperator(task_id='delete-topic')  # pylint:disable=no-value-for-parameter
 
     t1 >> t2 >> t3
     t2 >> t4 >> t5 >> t6 >> t7

--- a/tests/api/common/experimental/test_mark_tasks.py
+++ b/tests/api/common/experimental/test_mark_tasks.py
@@ -310,7 +310,7 @@ class TestMarkDAGRun(unittest.TestCase):
         # All except the SUCCESS task should be altered.
         self.assertEqual(len(altered), 5)
         self._verify_dag_run_state(self.dag1, date, State.SUCCESS)
-        self._verify_task_instance_states(self.dag1, date, State.SUCCESS)
+        self._verify_task_instance_states(self.dag1, date, State.SUCCESS)  # pylint:disable=no-value-for-parameter,line-too-long  # noqa
         self._verify_dag_run_dates(self.dag1, date, State.SUCCESS, middle_time)
 
     def test_set_running_dag_run_to_failed(self):
@@ -352,7 +352,7 @@ class TestMarkDAGRun(unittest.TestCase):
         # All except the SUCCESS task should be altered.
         self.assertEqual(len(altered), 5)
         self._verify_dag_run_state(self.dag1, date, State.SUCCESS)
-        self._verify_task_instance_states(self.dag1, date, State.SUCCESS)
+        self._verify_task_instance_states(self.dag1, date, State.SUCCESS)  # pylint:disable=no-value-for-parameter,line-too-long  # noqa
         self._verify_dag_run_dates(self.dag1, date, State.SUCCESS, middle_time)
 
     def test_set_success_dag_run_to_failed(self):
@@ -394,7 +394,7 @@ class TestMarkDAGRun(unittest.TestCase):
         # All except the SUCCESS task should be altered.
         self.assertEqual(len(altered), 5)
         self._verify_dag_run_state(self.dag1, date, State.SUCCESS)
-        self._verify_task_instance_states(self.dag1, date, State.SUCCESS)
+        self._verify_task_instance_states(self.dag1, date, State.SUCCESS)  # pylint:disable=no-value-for-parameter,line-too-long  # noqa
         self._verify_dag_run_dates(self.dag1, date, State.SUCCESS, middle_time)
 
     def test_set_failed_dag_run_to_failed(self):

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -955,7 +955,7 @@ class SchedulerJobTest(unittest.TestCase):
         test_executor = TestExecutor(do_update=False)
         scheduler_job.executor = test_executor
         scheduler_job._logger = mock_logger
-        scheduler_job._change_state_for_tasks_failed_to_execute()
+        scheduler_job._change_state_for_tasks_failed_to_execute()  # pylint:disable=no-value-for-parameter
         mock_logger.info.assert_not_called()
 
         # Tasks failed to execute with QUEUED state will be set to SCHEDULED state.
@@ -968,7 +968,7 @@ class SchedulerJobTest(unittest.TestCase):
         session.merge(ti)
         session.commit()
 
-        scheduler_job._change_state_for_tasks_failed_to_execute()
+        scheduler_job._change_state_for_tasks_failed_to_execute()  # pylint:disable=no-value-for-parameter
 
         ti.refresh_from_db()
         self.assertEqual(State.SCHEDULED, ti.state)
@@ -981,7 +981,7 @@ class SchedulerJobTest(unittest.TestCase):
         session.merge(ti)
         session.commit()
 
-        scheduler_job._change_state_for_tasks_failed_to_execute()
+        scheduler_job._change_state_for_tasks_failed_to_execute()  # pylint:disable=no-value-for-parameter
 
         ti.refresh_from_db()
         self.assertEqual(State.RUNNING, ti.state)
@@ -1835,11 +1835,11 @@ class SchedulerJobTest(unittest.TestCase):
             scheduler.heartrate = 0
             scheduler.run()
 
-        do_schedule()
+        do_schedule()  # pylint:disable=no-value-for-parameter
         self.assertEqual(1, len(executor.queued_tasks))
         executor.queued_tasks.clear()
 
-        do_schedule()
+        do_schedule()  # pylint:disable=no-value-for-parameter
         self.assertEqual(2, len(executor.queued_tasks))
 
     def test_scheduler_sla_miss_callback(self):
@@ -2077,7 +2077,7 @@ class SchedulerJobTest(unittest.TestCase):
             scheduler.heartrate = 0
             scheduler.run()
 
-        do_schedule()
+        do_schedule()  # pylint:disable=no-value-for-parameter
         self.assertEqual(1, len(executor.queued_tasks))
 
         def run_with_error(task):
@@ -2103,7 +2103,7 @@ class SchedulerJobTest(unittest.TestCase):
         session.commit()
 
         # do not schedule
-        do_schedule()
+        do_schedule()  # pylint:disable=no-value-for-parameter
         self.assertTrue(executor.has_task(ti))
         ti.refresh_from_db()
         # removing self.assertEqual(ti.state, State.SCHEDULED)
@@ -2113,7 +2113,7 @@ class SchedulerJobTest(unittest.TestCase):
         # but tasks stay in the executor.queued_tasks after executor.heartbeat()
         # will be set back to SCHEDULED state
         executor.queued_tasks.clear()
-        do_schedule()
+        do_schedule()  # pylint:disable=no-value-for-parameter
         ti.refresh_from_db()
 
         self.assertEqual(ti.state, State.SCHEDULED)
@@ -2121,7 +2121,7 @@ class SchedulerJobTest(unittest.TestCase):
         # To verify that task does get re-queued.
         executor.queued_tasks.clear()
         executor.do_update = True
-        do_schedule()
+        do_schedule()  # pylint:disable=no-value-for-parameter
         ti.refresh_from_db()
         self.assertIn(ti.state, [State.RUNNING, State.SUCCESS])
 

--- a/tests/models/test_pool.py
+++ b/tests/models/test_pool.py
@@ -60,10 +60,10 @@ class PoolTest(unittest.TestCase):
         session.commit()
         session.close()
 
-        self.assertEqual(3, pool.open_slots())
-        self.assertEqual(1, pool.used_slots())
-        self.assertEqual(1, pool.queued_slots())
-        self.assertEqual(2, pool.occupied_slots())
+        self.assertEqual(3, pool.open_slots())  # pylint:disable=no-value-for-parameter
+        self.assertEqual(1, pool.used_slots())  # pylint:disable=no-value-for-parameter
+        self.assertEqual(1, pool.queued_slots())  # pylint:disable=no-value-for-parameter
+        self.assertEqual(2, pool.occupied_slots())  # pylint:disable=no-value-for-parameter
 
     def test_default_pool_open_slots(self):
         set_default_pool_slots(5)

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -492,7 +492,7 @@ class TaskInstanceTest(unittest.TestCase):
             self.assertEqual(ti.start_date, expected_start_date)
             self.assertEqual(ti.end_date, expected_end_date)
             self.assertEqual(ti.duration, expected_duration)
-            trs = TaskReschedule.find_for_task_instance(ti)
+            trs = TaskReschedule.find_for_task_instance(ti)  # pylint:disable=no-value-for-parameter
             self.assertEqual(len(trs), expected_task_reschedule_count)
 
         date1 = timezone.utcnow()
@@ -630,7 +630,7 @@ class TaskInstanceTest(unittest.TestCase):
         run_date = task.start_date + datetime.timedelta(days=5)
 
         ti = TI(downstream, run_date)
-        dep_results = TriggerRuleDep()._evaluate_trigger_rule(
+        dep_results = TriggerRuleDep()._evaluate_trigger_rule(  # pylint:disable=no-value-for-parameter
             ti=ti,
             successes=successes,
             skipped=skipped,

--- a/tests/sensors/test_base_sensor.py
+++ b/tests/sensors/test_base_sensor.py
@@ -183,7 +183,7 @@ class BaseSensorTest(unittest.TestCase):
                 # verify task start date is the initial one
                 self.assertEqual(ti.start_date, date1)
                 # verify one row in task_reschedule table
-                task_reschedules = TaskReschedule.find_for_task_instance(ti)
+                task_reschedules = TaskReschedule.find_for_task_instance(ti)  # pylint:disable=no-value-for-parameter,line-too-long  # noqa
                 self.assertEqual(len(task_reschedules), 1)
                 self.assertEqual(task_reschedules[0].start_date, date1)
                 self.assertEqual(task_reschedules[0].reschedule_date,
@@ -204,7 +204,7 @@ class BaseSensorTest(unittest.TestCase):
                 # verify task start date is the initial one
                 self.assertEqual(ti.start_date, date1)
                 # verify two rows in task_reschedule table
-                task_reschedules = TaskReschedule.find_for_task_instance(ti)
+                task_reschedules = TaskReschedule.find_for_task_instance(ti)  # pylint:disable=no-value-for-parameter,line-too-long  # noqa
                 self.assertEqual(len(task_reschedules), 2)
                 self.assertEqual(task_reschedules[1].start_date, date2)
                 self.assertEqual(task_reschedules[1].reschedule_date,
@@ -310,7 +310,7 @@ class BaseSensorTest(unittest.TestCase):
             if ti.task_id == SENSOR_OP:
                 self.assertEqual(ti.state, State.UP_FOR_RESCHEDULE)
                 # verify one row in task_reschedule table
-                task_reschedules = TaskReschedule.find_for_task_instance(ti)
+                task_reschedules = TaskReschedule.find_for_task_instance(ti)  # pylint:disable=no-value-for-parameter,line-too-long  # noqa
                 self.assertEqual(len(task_reschedules), 1)
                 self.assertEqual(task_reschedules[0].start_date, date1)
                 self.assertEqual(task_reschedules[0].reschedule_date,
@@ -342,7 +342,7 @@ class BaseSensorTest(unittest.TestCase):
             if ti.task_id == SENSOR_OP:
                 self.assertEqual(ti.state, State.UP_FOR_RESCHEDULE)
                 # verify one row in task_reschedule table
-                task_reschedules = TaskReschedule.find_for_task_instance(ti)
+                task_reschedules = TaskReschedule.find_for_task_instance(ti)  # pylint:disable=no-value-for-parameter,line-too-long  # noqa
                 self.assertEqual(len(task_reschedules), 1)
                 self.assertEqual(task_reschedules[0].start_date, date3)
                 self.assertEqual(task_reschedules[0].reschedule_date,
@@ -398,7 +398,7 @@ class BaseSensorTest(unittest.TestCase):
                 # verify task is re-scheduled, i.e. state set to NONE
                 self.assertEqual(ti.state, State.UP_FOR_RESCHEDULE)
                 # verify one row in task_reschedule table
-                task_reschedules = TaskReschedule.find_for_task_instance(ti)
+                task_reschedules = TaskReschedule.find_for_task_instance(ti)  # pylint:disable=no-value-for-parameter,line-too-long  # noqa
                 self.assertEqual(len(task_reschedules), 1)
                 self.assertEqual(task_reschedules[0].start_date, date1)
                 self.assertEqual(task_reschedules[0].reschedule_date, date2)
@@ -415,7 +415,7 @@ class BaseSensorTest(unittest.TestCase):
                 # verify task is re-scheduled, i.e. state set to NONE
                 self.assertEqual(ti.state, State.UP_FOR_RESCHEDULE)
                 # verify two rows in task_reschedule table
-                task_reschedules = TaskReschedule.find_for_task_instance(ti)
+                task_reschedules = TaskReschedule.find_for_task_instance(ti)  # pylint:disable=no-value-for-parameter,line-too-long  # noqa
                 self.assertEqual(len(task_reschedules), 2)
                 self.assertEqual(task_reschedules[1].start_date, date2)
                 self.assertEqual(task_reschedules[1].reschedule_date, date3)
@@ -456,7 +456,7 @@ class BaseSensorTest(unittest.TestCase):
                 # in test mode state is not modified
                 self.assertEqual(ti.state, State.NONE)
                 # in test mode no reschedule request is recorded
-                task_reschedules = TaskReschedule.find_for_task_instance(ti)
+                task_reschedules = TaskReschedule.find_for_task_instance(ti)  # pylint:disable=no-value-for-parameter,line-too-long  # noqa
                 self.assertEqual(len(task_reschedules), 0)
             if ti.task_id == DUMMY_OP:
                 self.assertEqual(ti.state, State.NONE)

--- a/tests/utils/test_decorators.py
+++ b/tests/utils/test_decorators.py
@@ -48,11 +48,11 @@ class ApplyDefaultTest(unittest.TestCase):
 
     def test_default_args(self):
         default_args = {'test_param': True}
-        dc = DummyClass(default_args=default_args)
+        dc = DummyClass(default_args=default_args)  # pylint:disable=no-value-for-parameter
         self.assertTrue(dc.test_param)
 
         default_args = {'test_param': True, 'test_sub_param': True}
-        dsc = DummySubClass(default_args=default_args)
+        dsc = DummySubClass(default_args=default_args)  # pylint:disable=no-value-for-parameter
         self.assertTrue(dc.test_param)
         self.assertTrue(dsc.test_sub_param)
 
@@ -63,13 +63,13 @@ class ApplyDefaultTest(unittest.TestCase):
 
         with self.assertRaisesRegex(AirflowException,
                                     'Argument.*test_sub_param.*required'):
-            DummySubClass(default_args=default_args)
+            DummySubClass(default_args=default_args)  # pylint:disable=no-value-for-parameter
 
     def test_incorrect_default_args(self):
         default_args = {'test_param': True, 'extra_param': True}
-        dc = DummyClass(default_args=default_args)
+        dc = DummyClass(default_args=default_args)  # pylint:disable=no-value-for-parameter
         self.assertTrue(dc.test_param)
 
         default_args = {'random_params': True}
         with self.assertRaisesRegex(AirflowException, 'Argument.*test_param.*required'):
-            DummyClass(default_args=default_args)
+            DummyClass(default_args=default_args)  # pylint:disable=no-value-for-parameter


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
