### PR TITLE
Airflow 3278

### DIFF
--- a/airflow/contrib/operators/adls_to_gcs.py
+++ b/airflow/contrib/operators/adls_to_gcs.py
@@ -37,6 +37,8 @@ class AdlsToGoogleCloudStorageOperator(AzureDataLakeStorageListOperator):
     :type dest_gcs: str
     :param replace: If true, replaces same-named files in GCS
     :type replace: bool
+    :param gzip: Option to compress file for upload
+    :type gzip: bool
     :param azure_data_lake_conn_id: The connection ID to use when
         connecting to Azure Data Lake Storage.
     :type azure_data_lake_conn_id: str
@@ -97,6 +99,7 @@ class AdlsToGoogleCloudStorageOperator(AzureDataLakeStorageListOperator):
                  google_cloud_storage_conn_id,
                  delegate_to=None,
                  replace=False,
+                 gzip=False,
                  *args,
                  **kwargs):
 
@@ -111,6 +114,7 @@ class AdlsToGoogleCloudStorageOperator(AzureDataLakeStorageListOperator):
         self.replace = replace
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
         self.delegate_to = delegate_to
+        self.gzip = gzip
 
     def execute(self, context):
         # use the super to list all files in an Azure Data Lake path
@@ -140,8 +144,12 @@ class AdlsToGoogleCloudStorageOperator(AzureDataLakeStorageListOperator):
                     dest_path = os.path.join(dest_gcs_prefix, obj)
                     self.log.info("Saving file to %s", dest_path)
 
-                    g_hook.upload(bucket_name=dest_gcs_bucket,
-                                  object_name=dest_path, filename=f.name)
+                    g_hook.upload(
+                        bucket_name=dest_gcs_bucket,
+                        object_name=dest_path,
+                        filename=f.name,
+                        gzip=self.gzip
+                    )
 
             self.log.info("All done, uploaded %d files to GCS", len(files))
         else:

--- a/airflow/contrib/operators/s3_to_gcs_operator.py
+++ b/airflow/contrib/operators/s3_to_gcs_operator.py
@@ -65,6 +65,8 @@ class S3ToGoogleCloudStorageOperator(S3ListOperator):
     :param replace: Whether you want to replace existing destination files
         or not.
     :type replace: bool
+    :param gzip: Option to compress file for upload
+    :type gzip: bool
 
 
     **Example**:
@@ -78,6 +80,7 @@ class S3ToGoogleCloudStorageOperator(S3ListOperator):
             dest_gcs_conn_id='google_cloud_default',
             dest_gcs='gs://my.gcs.bucket/some/customers/',
             replace=False,
+            gzip=True,
             dag=my-dag)
 
     Note that ``bucket``, ``prefix``, ``delimiter`` and ``dest_gcs`` are
@@ -98,6 +101,7 @@ class S3ToGoogleCloudStorageOperator(S3ListOperator):
                  dest_gcs=None,
                  delegate_to=None,
                  replace=False,
+                 gzip=False,
                  *args,
                  **kwargs):
 
@@ -113,6 +117,7 @@ class S3ToGoogleCloudStorageOperator(S3ListOperator):
         self.delegate_to = delegate_to
         self.replace = replace
         self.verify = verify
+        self.gzip = gzip
 
         if dest_gcs and not self._gcs_object_is_directory(self.dest_gcs):
             self.log.info(
@@ -186,7 +191,7 @@ class S3ToGoogleCloudStorageOperator(S3ListOperator):
                     #                             dest_gcs_bucket,
                     #                             dest_gcs_object))
 
-                    gcs_hook.upload(dest_gcs_bucket, dest_gcs_object, f.name)
+                    gcs_hook.upload(dest_gcs_bucket, dest_gcs_object, f.name, gzip=self.gzip)
 
             self.log.info(
                 "All done, uploaded %d files to Google Cloud Storage",

--- a/tests/contrib/operators/test_adls_to_gcs_operator.py
+++ b/tests/contrib/operators/test_adls_to_gcs_operator.py
@@ -72,15 +72,17 @@ class AdlsToGoogleCloudStorageOperatorTest(unittest.TestCase):
         adls_one_mock_hook.return_value.list.return_value = MOCK_FILES
         adls_two_mock_hook.return_value.list.return_value = MOCK_FILES
 
-        def _assert_upload(bucket_name, object_name, filename):  # pylint: disable=unused-argument
-            gcs_bucket, gcs_object_path = _parse_gcs_url(GCS_PATH)
-
-            self.assertEqual(gcs_bucket, 'test')
-            self.assertIn(object_name[len(gcs_object_path):], MOCK_FILES)
-
-        gcs_mock_hook.return_value.upload.side_effect = _assert_upload
-
+        # gcs_mock_hook.return_value.upload.side_effect = _assert_upload
         uploaded_files = operator.execute(None)
+        gcs_mock_hook.return_value.upload.assert_has_calls(
+            [
+                mock.call(bucket_name='test', filename=mock.ANY, object_name='test/path/PARQUET.parquet', gzip=True),
+                mock.call(bucket_name='test', filename=mock.ANY, object_name='test/path/TEST3.csv', gzip=True),
+                mock.call(bucket_name='test', filename=mock.ANY, object_name='test/path/PIC.png', gzip=True),
+                mock.call(bucket_name='test', filename=mock.ANY, object_name='test/TEST1.csv', gzip=True),
+                mock.call(bucket_name='test', filename=mock.ANY, object_name='test/TEST2.csv', gzip=True)
+            ], any_order=True
+        )
 
         adls_one_mock_hook.assert_called_once_with(azure_data_lake_conn_id=AZURE_CONN_ID)
         adls_two_mock_hook.assert_called_once_with(azure_data_lake_conn_id=AZURE_CONN_ID)
@@ -90,6 +92,40 @@ class AdlsToGoogleCloudStorageOperatorTest(unittest.TestCase):
         # we expect MOCK_FILES to be uploaded
         self.assertEqual(sorted(MOCK_FILES), sorted(uploaded_files))
 
+    @mock.patch('airflow.contrib.operators.adls_to_gcs.AzureDataLakeHook')
+    @mock.patch('airflow.contrib.operators.adls_list_operator.AzureDataLakeHook')
+    @mock.patch(
+        'airflow.contrib.operators.adls_to_gcs.GoogleCloudStorageHook')
+    def test_execute_with_gzip(self, gcs_mock_hook, adls_one_mock_hook, adls_two_mock_hook):
+        """Test the execute function when the run is successful."""
+
+        operator = AdlsToGoogleCloudStorageOperator(
+            task_id=TASK_ID,
+            src_adls=ADLS_PATH_1,
+            dest_gcs=GCS_PATH,
+            replace=False,
+            azure_data_lake_conn_id=AZURE_CONN_ID,
+            google_cloud_storage_conn_id=GCS_CONN_ID,
+            gzip=True
+        )
+
+        adls_one_mock_hook.return_value.list.return_value = MOCK_FILES
+        adls_two_mock_hook.return_value.list.return_value = MOCK_FILES
+
+        # gcs_mock_hook.return_value.upload.side_effect = _assert_upload
+        uploaded_files = operator.execute(None)
+        gcs_mock_hook.return_value.upload.assert_has_calls(
+            [
+                mock.call(bucket_name='test', filename=mock.ANY, object_name='test/path/PARQUET.parquet', gzip=True),
+                mock.call(bucket_name='test', filename=mock.ANY, object_name='test/path/TEST3.csv', gzip=True),
+                mock.call(bucket_name='test', filename=mock.ANY, object_name='test/path/PIC.png', gzip=True),
+                mock.call(bucket_name='test', filename=mock.ANY, object_name='test/TEST1.csv', gzip=True),
+                mock.call(bucket_name='test', filename=mock.ANY, object_name='test/TEST2.csv', gzip=True)
+            ], any_order=True
+        )
+
+        # we expect MOCK_FILES to be uploaded
+        self.assertEqual(sorted(MOCK_FILES), sorted(uploaded_files))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/contrib/operators/test_adls_to_gcs_operator.py
+++ b/tests/contrib/operators/test_adls_to_gcs_operator.py
@@ -146,5 +146,6 @@ class AdlsToGoogleCloudStorageOperatorTest(unittest.TestCase):
         # we expect MOCK_FILES to be uploaded
         self.assertEqual(sorted(MOCK_FILES), sorted(uploaded_files))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/contrib/operators/test_adls_to_gcs_operator.py
+++ b/tests/contrib/operators/test_adls_to_gcs_operator.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-from airflow.contrib.hooks.gcs_hook import _parse_gcs_url
 from airflow.contrib.operators.adls_to_gcs import \
     AdlsToGoogleCloudStorageOperator
 from tests.compat import mock
@@ -76,8 +75,18 @@ class AdlsToGoogleCloudStorageOperatorTest(unittest.TestCase):
         uploaded_files = operator.execute(None)
         gcs_mock_hook.return_value.upload.assert_has_calls(
             [
-                mock.call(bucket_name='test', filename=mock.ANY, object_name='test/path/PARQUET.parquet', gzip=True),
-                mock.call(bucket_name='test', filename=mock.ANY, object_name='test/path/TEST3.csv', gzip=True),
+                mock.call(
+                    bucket_name='test',
+                    filename=mock.ANY,
+                    object_name='test/path/PARQUET.parquet',
+                    gzip=True
+                ),
+                mock.call(
+                    bucket_name='test',
+                    filename=mock.ANY,
+                    object_name='test/path/TEST3.csv',
+                    gzip=True
+                ),
                 mock.call(bucket_name='test', filename=mock.ANY, object_name='test/path/PIC.png', gzip=True),
                 mock.call(bucket_name='test', filename=mock.ANY, object_name='test/TEST1.csv', gzip=True),
                 mock.call(bucket_name='test', filename=mock.ANY, object_name='test/TEST2.csv', gzip=True)
@@ -116,8 +125,18 @@ class AdlsToGoogleCloudStorageOperatorTest(unittest.TestCase):
         uploaded_files = operator.execute(None)
         gcs_mock_hook.return_value.upload.assert_has_calls(
             [
-                mock.call(bucket_name='test', filename=mock.ANY, object_name='test/path/PARQUET.parquet', gzip=True),
-                mock.call(bucket_name='test', filename=mock.ANY, object_name='test/path/TEST3.csv', gzip=True),
+                mock.call(
+                    bucket_name='test',
+                    filename=mock.ANY,
+                    object_name='test/path/PARQUET.parquet',
+                    gzip=True
+                ),
+                mock.call(
+                    bucket_name='test',
+                    filename=mock.ANY,
+                    object_name='test/path/TEST3.csv',
+                    gzip=True
+                ),
                 mock.call(bucket_name='test', filename=mock.ANY, object_name='test/path/PIC.png', gzip=True),
                 mock.call(bucket_name='test', filename=mock.ANY, object_name='test/TEST1.csv', gzip=True),
                 mock.call(bucket_name='test', filename=mock.ANY, object_name='test/TEST2.csv', gzip=True)

--- a/tests/contrib/operators/test_s3_to_gcs_operator.py
+++ b/tests/contrib/operators/test_s3_to_gcs_operator.py
@@ -71,15 +71,14 @@ class S3ToGoogleCloudStorageOperatorTest(unittest.TestCase):
         s3_one_mock_hook.return_value.list_keys.return_value = MOCK_FILES
         s3_two_mock_hook.return_value.list_keys.return_value = MOCK_FILES
 
-        def _assert_upload(bucket, object, _):
-            gcs_bucket, gcs_object_path = _parse_gcs_url(GCS_PATH_PREFIX)
-
-            self.assertEqual(gcs_bucket, bucket)
-            self.assertIn(object[len(gcs_object_path):], MOCK_FILES)
-
-        gcs_mock_hook.return_value.upload.side_effect = _assert_upload
-
         uploaded_files = operator.execute(None)
+        gcs_mock_hook.return_value.upload.assert_has_calls(
+            [
+                mock.call('gcs-bucket', 'data/TEST1.csv', mock.ANY, gzip=False),
+                mock.call('gcs-bucket', 'data/TEST3.csv', mock.ANY, gzip=False),
+                mock.call('gcs-bucket', 'data/TEST2.csv', mock.ANY, gzip=False)
+            ], any_order=True
+        )
 
         s3_one_mock_hook.assert_called_once_with(aws_conn_id=AWS_CONN_ID, verify=None)
         s3_two_mock_hook.assert_called_once_with(aws_conn_id=AWS_CONN_ID, verify=None)
@@ -88,6 +87,35 @@ class S3ToGoogleCloudStorageOperatorTest(unittest.TestCase):
 
         # we expect MOCK_FILES to be uploaded
         self.assertEqual(sorted(MOCK_FILES), sorted(uploaded_files))
+
+    @mock.patch('airflow.contrib.operators.s3_to_gcs_operator.S3Hook')
+    @mock.patch('airflow.contrib.operators.s3_list_operator.S3Hook')
+    @mock.patch(
+        'airflow.contrib.operators.s3_to_gcs_operator.GoogleCloudStorageHook')
+    def test_execute_with_gzip(self, gcs_mock_hook, s3_one_mock_hook, s3_two_mock_hook):
+        """Test the execute function when the run is successful."""
+
+        operator = S3ToGoogleCloudStorageOperator(
+            task_id=TASK_ID,
+            bucket=S3_BUCKET,
+            prefix=S3_PREFIX,
+            delimiter=S3_DELIMITER,
+            dest_gcs_conn_id=GCS_CONN_ID,
+            dest_gcs=GCS_PATH_PREFIX,
+            gzip=True
+        )
+
+        s3_one_mock_hook.return_value.list_keys.return_value = MOCK_FILES
+        s3_two_mock_hook.return_value.list_keys.return_value = MOCK_FILES
+
+        uploaded_files = operator.execute(None)
+        gcs_mock_hook.return_value.upload.assert_has_calls(
+            [
+                mock.call('gcs-bucket', 'data/TEST2.csv', mock.ANY, gzip=True),
+                mock.call('gcs-bucket', 'data/TEST1.csv', mock.ANY, gzip=True),
+                mock.call('gcs-bucket', 'data/TEST3.csv', mock.ANY, gzip=True)
+            ], any_order=True
+        )
 
 
 if __name__ == '__main__':

--- a/tests/contrib/operators/test_s3_to_gcs_operator.py
+++ b/tests/contrib/operators/test_s3_to_gcs_operator.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-from airflow.contrib.hooks.gcs_hook import _parse_gcs_url
 from airflow.contrib.operators.s3_to_gcs_operator import \
     S3ToGoogleCloudStorageOperator
 from tests.compat import mock
@@ -108,7 +107,7 @@ class S3ToGoogleCloudStorageOperatorTest(unittest.TestCase):
         s3_one_mock_hook.return_value.list_keys.return_value = MOCK_FILES
         s3_two_mock_hook.return_value.list_keys.return_value = MOCK_FILES
 
-        uploaded_files = operator.execute(None)
+        operator.execute(None)
         gcs_mock_hook.return_value.upload.assert_has_calls(
             [
                 mock.call('gcs-bucket', 'data/TEST2.csv', mock.ANY, gzip=True),


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3278
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
