### PR TITLE
[WIP] Use assert called once with

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -280,7 +280,7 @@ class TestCLI(unittest.TestCase):
             'dags', 'backfill', 'example_bash_operator',
             '-s', DEFAULT_DATE.isoformat()]))
 
-        mock_run.assert_called_with(
+        mock_run.assert_called_once_with(
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE,
             conf=None,
@@ -324,7 +324,7 @@ class TestCLI(unittest.TestCase):
             'dags', 'backfill', 'example_bash_operator', '-l',
             '-s', DEFAULT_DATE.isoformat()]), dag=dag)
 
-        mock_run.assert_called_with(
+        mock_run.assert_called_once_with(
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE,
             conf=None,
@@ -364,7 +364,7 @@ class TestCLI(unittest.TestCase):
 
         cli.backfill(self.parser.parse_args(args), dag=dag)
 
-        mock_run.assert_called_with(
+        mock_run.assert_called_once_with(
             start_date=run_date,
             end_date=run_date,
             conf=None,
@@ -403,7 +403,7 @@ class TestCLI(unittest.TestCase):
         dag = self.dagbag.get_dag(dag_id)
 
         cli.backfill(self.parser.parse_args(args), dag=dag)
-        mock_run.assert_called_with(
+        mock_run.assert_called_once_with(
             start_date=start_date,
             end_date=end_date,
             conf=None,
@@ -439,7 +439,7 @@ class TestCLI(unittest.TestCase):
                  NAIVE_DATE.isoformat()]
 
         cli.run(self.parser.parse_args(args0), dag=dag)
-        mock_local_job.assert_called_with(
+        mock_local_job.assert_called_once_with(
             task_instance=mock.ANY,
             mark_success=False,
             ignore_all_deps=True,

--- a/tests/contrib/hooks/test_aws_hook.py
+++ b/tests/contrib/hooks/test_aws_hook.py
@@ -150,7 +150,7 @@ class TestAwsHook(unittest.TestCase):
         mock_get_connection.return_value = mock_connection
         hook = AwsHook()
         hook._get_credentials(region_name=None)
-        mock_parse_s3_config.assert_called_with(
+        mock_parse_s3_config.assert_called_once_with(
             'aws-credentials',
             'aws',
             'test'

--- a/tests/contrib/hooks/test_azure_container_instance_hook.py
+++ b/tests/contrib/hooks/test_azure_container_instance_hook.py
@@ -58,12 +58,12 @@ class TestAzureContainerInstanceHook(unittest.TestCase):
     @patch('azure.mgmt.containerinstance.operations.ContainerGroupsOperations.create_or_update')
     def test_create_or_update(self, create_or_update_mock, container_group_mock):
         self.testHook.create_or_update('resource_group', 'aci-test', container_group_mock)
-        create_or_update_mock.assert_called_with('resource_group', 'aci-test', container_group_mock)
+        create_or_update_mock.assert_called_once_with('resource_group', 'aci-test', container_group_mock)
 
     @patch('azure.mgmt.containerinstance.operations.ContainerGroupsOperations.get')
     def test_get_state(self, get_state_mock):
         self.testHook.get_state('resource_group', 'aci-test')
-        get_state_mock.assert_called_with('resource_group', 'aci-test', raw=False)
+        get_state_mock.assert_called_once_with('resource_group', 'aci-test', raw=False)
 
     @patch('azure.mgmt.containerinstance.operations.ContainerOperations.list_logs')
     def test_get_logs(self, list_logs_mock):
@@ -78,7 +78,7 @@ class TestAzureContainerInstanceHook(unittest.TestCase):
     @patch('azure.mgmt.containerinstance.operations.ContainerGroupsOperations.delete')
     def test_delete(self, delete_mock):
         self.testHook.delete('resource_group', 'aci-test')
-        delete_mock.assert_called_with('resource_group', 'aci-test')
+        delete_mock.assert_called_once_with('resource_group', 'aci-test')
 
     @patch('azure.mgmt.containerinstance.operations.ContainerGroupsOperations.list_by_resource_group')
     def test_exists_with_existing(self, list_mock):

--- a/tests/contrib/hooks/test_azure_data_lake_hook.py
+++ b/tests/contrib/hooks/test_azure_data_lake_hook.py
@@ -98,7 +98,7 @@ class TestAzureDataLakeHook(unittest.TestCase):
         from airflow.contrib.hooks.azure_data_lake_hook import AzureDataLakeHook
         hook = AzureDataLakeHook(azure_data_lake_conn_id='adl_test_key')
         hook.list('file_path/*')
-        mock_fs.return_value.glob.assert_called_with('file_path/*')
+        mock_fs.return_value.glob.assert_called_once_with('file_path/*')
 
     @mock.patch('airflow.contrib.hooks.azure_data_lake_hook.core.AzureDLFileSystem',
                 autospec=True)
@@ -107,7 +107,7 @@ class TestAzureDataLakeHook(unittest.TestCase):
         from airflow.contrib.hooks.azure_data_lake_hook import AzureDataLakeHook
         hook = AzureDataLakeHook(azure_data_lake_conn_id='adl_test_key')
         hook.list('file_path/some_folder/')
-        mock_fs.return_value.walk.assert_called_with('file_path/some_folder/')
+        mock_fs.return_value.walk.assert_called_once_with('file_path/some_folder/')
 
 
 if __name__ == '__main__':

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -273,7 +273,7 @@ class TestBigQueryBaseCursor(unittest.TestCase):
 
         bq_hook.cancel_query()
 
-        mock_jobs.cancel.assert_called_with(projectId=project_id, jobId=running_job_id)
+        mock_jobs.cancel.assert_called_once_with(projectId=project_id, jobId=running_job_id)
 
     @mock.patch.object(hook.BigQueryBaseCursor, 'run_with_configuration')
     def test_run_query_sql_dialect_default(self, run_with_config):
@@ -368,8 +368,12 @@ class TestTableDataOperations(unittest.TestCase):
         }
         cursor = hook.BigQueryBaseCursor(mock_service, 'project_id')
         cursor.insert_all(project_id, dataset_id, table_id, rows)
-        method.assert_called_with(projectId=project_id, datasetId=dataset_id,
-                                  tableId=table_id, body=body)
+        method.assert_called_once_with(
+            projectId=project_id,
+            datasetId=dataset_id,
+            tableId=table_id,
+            body=body
+        )
 
     def test_insert_all_fail(self):
         project_id = 'bq-project'

--- a/tests/contrib/hooks/test_databricks_hook.py
+++ b/tests/contrib/hooks/test_databricks_hook.py
@@ -249,7 +249,11 @@ class TestDatabricksHook(unittest.TestCase):
                         self.hook._do_api_call(SUBMIT_RUN_ENDPOINT, {})
 
                     self.assertEqual(len(mock_sleep.mock_calls), self.hook.retry_limit - 1)
-                    mock_sleep.assert_called_with(retry_delay)
+                    calls = [
+                        mock.call(retry_delay),
+                        mock.call(retry_delay)
+                    ]
+                    mock_sleep.assert_has_calls(calls)
 
     @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
     def test_submit_run(self, mock_requests):

--- a/tests/contrib/hooks/test_datadog_hook.py
+++ b/tests/contrib/hooks/test_datadog_hook.py
@@ -85,7 +85,7 @@ class TestDatadogHook(unittest.TestCase):
             type_=TYPE,
             interval=INTERVAL,
         )
-        mock_send.assert_called_with(
+        mock_send.assert_called_once_with(
             metric=METRIC_NAME,
             points=DATAPOINT,
             host=self.hook.host,
@@ -101,7 +101,7 @@ class TestDatadogHook(unittest.TestCase):
         mock_time.return_value = now
         mock_query.return_value = {'status': 'ok'}
         self.hook.query_metric('query', 60, 30)
-        mock_query.assert_called_with(
+        mock_query.assert_called_once_with(
             start=now - 60,
             end=now - 30,
             query='query',
@@ -122,7 +122,7 @@ class TestDatadogHook(unittest.TestCase):
             tags=TAGS,
             device_name=DEVICE_NAME,
         )
-        mock_create.assert_called_with(
+        mock_create.assert_called_once_with(
             title=TITLE,
             text=TEXT,
             aggregation_key=AGGREGATION_KEY,

--- a/tests/contrib/hooks/test_ftp_hook.py
+++ b/tests/contrib/hooks/test_ftp_hook.py
@@ -144,7 +144,7 @@ class TestIntegrationFTPHook(unittest.TestCase):
     def _test_mode(self, hook_type, connection_id, expected_mode):
         hook = hook_type(connection_id)
         conn = hook.get_conn()
-        conn.set_pasv.assert_called_with(expected_mode)
+        conn.set_pasv.assert_called_once_with(expected_mode)
 
     @mock.patch("ftplib.FTP")
     def test_ftp_passive_mode(self, mock_ftp):

--- a/tests/contrib/hooks/test_gcs_hook.py
+++ b/tests/contrib/hooks/test_gcs_hook.py
@@ -368,7 +368,7 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
         self.assertEqual(sample_bucket.storage_class, test_storage_class)
         self.assertEqual(sample_bucket.labels, test_labels)
 
-        mock_service.return_value.bucket.return_value.create.assert_called_with(
+        mock_service.return_value.bucket.return_value.create.assert_called_once_with(
             project=test_project, location=test_location
         )
 
@@ -401,11 +401,11 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
         )
         self.assertEqual(response, sample_bucket.id)
 
-        mock_service.return_value.bucket.return_value._patch_property.assert_called_with(
+        mock_service.return_value.bucket.return_value._patch_property.assert_called_once_with(
             name='versioning', value=test_versioning_enabled
         )
 
-        mock_service.return_value.bucket.return_value.create.assert_called_with(
+        mock_service.return_value.bucket.return_value.create.assert_called_once_with(
             project=test_project, location=test_location
         )
 

--- a/tests/contrib/hooks/test_spark_sql_hook.py
+++ b/tests/contrib/hooks/test_spark_sql_hook.py
@@ -93,12 +93,12 @@ class TestSparkSqlHook(unittest.TestCase):
         with patch.object(hook.log, 'debug') as mock_debug:
             with patch.object(hook.log, 'info') as mock_info:
                 hook.run_query()
-                mock_debug.assert_called_with(
+                mock_debug.assert_called_once_with(
                     'Spark-Sql cmd: %s',
                     ['spark-sql', '-e', 'SELECT 1', '--master', 'yarn', '--name', 'default-name', '--verbose',
                      '--queue', 'default']
                 )
-                mock_info.assert_called_with(
+                mock_info.assert_called_once_with(
                     'Spark-sql communicates using stdout'
                 )
 

--- a/tests/contrib/hooks/test_zendesk_hook.py
+++ b/tests/contrib/hooks/test_zendesk_hook.py
@@ -46,7 +46,7 @@ class TestZendeskHook(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             zendesk_hook.call("some_path", get_all_pages=False)
-            mocked_time.sleep.assert_called_with(sleep_time)
+            mocked_time.sleep.assert_called_once_with(sleep_time)
 
     @mock.patch("airflow.hooks.zendesk_hook.Zendesk")
     def test_returns_single_page_if_get_all_pages_false(self, _):
@@ -92,8 +92,8 @@ class TestZendeskHook(unittest.TestCase):
         zendesk_hook = ZendeskHook("conn_id")
         zendesk_hook.get_connection = mock.Mock(return_value=conn_mock)
         zendesk_hook.get_conn()
-        mock_zendesk.assert_called_with(zdesk_url='https://conn_host', zdesk_email='conn_login',
-                                        zdesk_password='conn_pass', zdesk_token=True)
+        mock_zendesk.assert_called_once_with(zdesk_url='https://conn_host', zdesk_email='conn_login',
+                                             zdesk_password='conn_pass', zdesk_token=True)
 
     @mock.patch("airflow.hooks.zendesk_hook.Zendesk")
     def test_zdesk_sideloading_works_correctly(self, mock_zendesk):

--- a/tests/contrib/operators/test_gcs_to_gcs_operator.py
+++ b/tests/contrib/operators/test_gcs_to_gcs_operator.py
@@ -304,7 +304,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
 
         with patch.object(operator.log, 'warning') as mock_warn:
             operator.execute(None)
-            mock_warn.assert_called_with(
+            mock_warn.assert_called_once_with(
                 'destination_bucket is None. Defaulting it to source_bucket (%s)',
                 TEST_BUCKET
             )

--- a/tests/contrib/operators/test_jenkins_operator.py
+++ b/tests/contrib/operators/test_jenkins_operator.py
@@ -64,8 +64,8 @@ class TestJenkinsOperator(unittest.TestCase):
             operator.execute(None)
 
             self.assertEqual(jenkins_mock.get_build_info.call_count, 1)
-            jenkins_mock.get_build_info.assert_called_with(name='a_job_on_jenkins',
-                                                           number='1')
+            jenkins_mock.get_build_info.assert_called_once_with(name='a_job_on_jenkins',
+                                                                number='1')
 
     @unittest.skipIf(mock is None, 'mock package not present')
     def test_execute_job_polling_loop(self):

--- a/tests/contrib/operators/test_oracle_to_oracle_transfer.py
+++ b/tests/contrib/operators/test_oracle_to_oracle_transfer.py
@@ -18,6 +18,7 @@
 # under the License.
 
 import unittest
+from unittest import mock
 from airflow.contrib.operators.oracle_to_oracle_transfer \
     import OracleToOracleTransfer
 from tests.compat import MagicMock
@@ -59,8 +60,13 @@ class TestOracleToOracleTransfer(unittest.TestCase):
 
         assert mock_src_hook.get_conn.called
         assert mock_src_conn.cursor.called
-        mock_cursor.execute.assert_called_with(source_sql, source_sql_params)
-        mock_cursor.fetchmany.assert_called_with(rows_chunk)
+        mock_cursor.execute.assert_called_once_with(source_sql, source_sql_params)
+
+        calls = [
+            mock.call(rows_chunk),
+            mock.call(rows_chunk),
+        ]
+        mock_cursor.fetchmany.assert_has_calls(calls)
         mock_dest_hook.bulk_insert_rows.assert_called_once_with(
             destination_table,
             cursor_rows,

--- a/tests/contrib/operators/test_qubole_check_operator.py
+++ b/tests/contrib/operators/test_qubole_check_operator.py
@@ -70,7 +70,7 @@ class TestQuboleValueCheckOperator(unittest.TestCase):
 
         operator.execute(None)
 
-        mock_hook.get_first.assert_called_with(query)
+        mock_hook.get_first.assert_called_once_with(query)
 
     @mock.patch.object(QuboleValueCheckOperator, 'get_hook')
     def test_execute_assertion_fail(self, mock_get_hook):
@@ -92,7 +92,7 @@ class TestQuboleValueCheckOperator(unittest.TestCase):
                                     'Qubole Command Id: ' + str(mock_cmd.id)):
             operator.execute()
 
-        mock_cmd.is_success.assert_called_with(mock_cmd.status)
+        mock_cmd.is_success.assert_called_once_with(mock_cmd.status)
 
     @mock.patch.object(QuboleValueCheckOperator, 'get_hook')
     def test_execute_assert_query_fail(self, mock_get_hook):
@@ -114,7 +114,7 @@ class TestQuboleValueCheckOperator(unittest.TestCase):
             operator.execute()
 
         self.assertNotIn('Qubole Command Id: ', str(cm.exception))
-        mock_cmd.is_success.assert_called_with(mock_cmd.status)
+        mock_cmd.is_success.assert_called_once_with(mock_cmd.status)
 
     @mock.patch.object(QuboleCheckHook, 'get_query_results')
     @mock.patch.object(QuboleHook, 'execute')

--- a/tests/contrib/sensors/test_emr_job_flow_sensor.py
+++ b/tests/contrib/sensors/test_emr_job_flow_sensor.py
@@ -163,7 +163,11 @@ class TestEmrJobFlowSensor(unittest.TestCase):
             self.assertEqual(self.mock_emr_client.describe_cluster.call_count, 2)
 
             # make sure it was called with the job_flow_id
-            self.mock_emr_client.describe_cluster.assert_called_with(ClusterId='j-8989898989')
+            calls = [
+                unittest.mock.call(ClusterId='j-8989898989'),
+                unittest.mock.call(ClusterId='j-8989898989')
+            ]
+            self.mock_emr_client.describe_cluster.assert_has_calls(calls)
 
     def test_execute_calls_with_the_job_flow_id_until_it_reaches_failed_state_with_exception(self):
         self.mock_emr_client.describe_cluster.side_effect = [
@@ -185,7 +189,7 @@ class TestEmrJobFlowSensor(unittest.TestCase):
                 self.assertEqual(self.mock_emr_client.describe_cluster.call_count, 2)
 
                 # make sure it was called with the job_flow_id
-                self.mock_emr_client.describe_cluster.assert_called_with(ClusterId='j-8989898989')
+                self.mock_emr_client.describe_cluster.assert_called_once_with(ClusterId='j-8989898989')
 
 
 if __name__ == '__main__':

--- a/tests/contrib/sensors/test_emr_step_sensor.py
+++ b/tests/contrib/sensors/test_emr_step_sensor.py
@@ -202,10 +202,11 @@ class TestEmrStepSensor(unittest.TestCase):
             self.sensor.execute(None)
 
             self.assertEqual(self.emr_client_mock.describe_step.call_count, 2)
-            self.emr_client_mock.describe_step.assert_called_with(
-                ClusterId='j-8989898989',
-                StepId='s-VK57YR1Z9Z5N'
-            )
+            calls = [
+                unittest.mock.call(ClusterId='j-8989898989', StepId='s-VK57YR1Z9Z5N'),
+                unittest.mock.call(ClusterId='j-8989898989', StepId='s-VK57YR1Z9Z5N')
+            ]
+            self.emr_client_mock.describe_step.assert_has_calls(calls)
 
     def test_step_cancelled(self):
         self.emr_client_mock.describe_step.side_effect = [

--- a/tests/contrib/sensors/test_gcs_sensor.py
+++ b/tests/contrib/sensors/test_gcs_sensor.py
@@ -158,11 +158,11 @@ class TestGoogleCloudStoragePrefixSensor(TestCase):
 
         response = task.execute(None)
 
-        mock_hook.assert_called_with(
+        mock_hook.assert_called_once_with(
             delegate_to=TEST_DELEGATE_TO,
             google_cloud_storage_conn_id=TEST_GCP_CONN_ID
         )
-        mock_hook.return_value.list.assert_called_with(TEST_BUCKET, prefix=TEST_PREFIX)
+        mock_hook.return_value.list.assert_called_once_with(TEST_BUCKET, prefix=TEST_PREFIX)
         self.assertEqual(response, generated_messages)
 
     @mock.patch('airflow.contrib.sensors.gcs_sensor.GoogleCloudStorageHook')
@@ -176,5 +176,5 @@ class TestGoogleCloudStoragePrefixSensor(TestCase):
         mock_hook.return_value.list.return_value = []
         with self.assertRaises(AirflowSensorTimeout):
             task.execute(mock.MagicMock)
-            mock_hook.return_value.list.assert_called_with(
+            mock_hook.return_value.list.assert_called_once_with(
                 TEST_BUCKET, prefix=TEST_PREFIX)

--- a/tests/contrib/sensors/test_sagemaker_endpoint_sensor.py
+++ b/tests/contrib/sensors/test_sagemaker_endpoint_sensor.py
@@ -92,7 +92,12 @@ class TestSageMakerEndpointSensor(unittest.TestCase):
         self.assertEqual(mock_describe.call_count, 3)
 
         # make sure the hook was initialized with the specific params
-        hook_init.assert_called_with(aws_conn_id='aws_test')
+        calls = [
+            mock.call(aws_conn_id='aws_test'),
+            mock.call(aws_conn_id='aws_test'),
+            mock.call(aws_conn_id='aws_test')
+        ]
+        hook_init.assert_has_calls(calls)
 
 
 if __name__ == '__main__':

--- a/tests/contrib/sensors/test_sagemaker_training_sensor.py
+++ b/tests/contrib/sensors/test_sagemaker_training_sensor.py
@@ -95,7 +95,12 @@ class TestSageMakerTrainingSensor(unittest.TestCase):
         self.assertEqual(mock_describe_job.call_count, 3)
 
         # make sure the hook was initialized with the specific params
-        hook_init.assert_called_with(aws_conn_id='aws_test')
+        calls = [
+            mock.call(aws_conn_id='aws_test'),
+            mock.call(aws_conn_id='aws_test'),
+            mock.call(aws_conn_id='aws_test')
+        ]
+        hook_init.assert_has_calls(calls)
 
     @mock.patch.object(SageMakerHook, 'get_conn')
     @mock.patch.object(AwsLogsHook, 'get_conn')
@@ -125,7 +130,12 @@ class TestSageMakerTrainingSensor(unittest.TestCase):
         self.assertEqual(mock_describe_job_with_log.call_count, 3)
         self.assertEqual(mock_describe_job.call_count, 1)
 
-        hook_init.assert_called_with(aws_conn_id='aws_test')
+        calls = [
+            mock.call(aws_conn_id='aws_test'),
+            mock.call(aws_conn_id='aws_test'),
+            mock.call(aws_conn_id='aws_test')
+        ]
+        hook_init.assert_has_calls(calls)
 
 
 if __name__ == '__main__':

--- a/tests/contrib/sensors/test_sagemaker_transform_sensor.py
+++ b/tests/contrib/sensors/test_sagemaker_transform_sensor.py
@@ -90,7 +90,12 @@ class TestSageMakerTransformSensor(unittest.TestCase):
         self.assertEqual(mock_describe_job.call_count, 3)
 
         # make sure the hook was initialized with the specific params
-        hook_init.assert_called_with(aws_conn_id='aws_test')
+        calls = [
+            mock.call(aws_conn_id='aws_test'),
+            mock.call(aws_conn_id='aws_test'),
+            mock.call(aws_conn_id='aws_test')
+        ]
+        hook_init.assert_has_calls(calls)
 
 
 if __name__ == '__main__':

--- a/tests/contrib/sensors/test_sagemaker_tuning_sensor.py
+++ b/tests/contrib/sensors/test_sagemaker_tuning_sensor.py
@@ -93,7 +93,12 @@ class TestSageMakerTuningSensor(unittest.TestCase):
         self.assertEqual(mock_describe_job.call_count, 3)
 
         # make sure the hook was initialized with the specific params
-        hook_init.assert_called_with(aws_conn_id='aws_test')
+        calls = [
+            mock.call(aws_conn_id='aws_test'),
+            mock.call(aws_conn_id='aws_test'),
+            mock.call(aws_conn_id='aws_test'),
+        ]
+        hook_init.assert_has_calls(calls)
 
 
 if __name__ == '__main__':

--- a/tests/contrib/sensors/test_sftp_sensor.py
+++ b/tests/contrib/sensors/test_sftp_sensor.py
@@ -34,7 +34,7 @@ class TestSFTPSensor(unittest.TestCase):
             'ds': '1970-01-01'
         }
         output = sftp_sensor.poke(context)
-        sftp_hook_mock.return_value.get_mod_time.assert_called_with(
+        sftp_hook_mock.return_value.get_mod_time.assert_called_once_with(
             '/path/to/file/1970-01-01.txt')
         self.assertTrue(output)
 
@@ -49,7 +49,7 @@ class TestSFTPSensor(unittest.TestCase):
             'ds': '1970-01-01'
         }
         output = sftp_sensor.poke(context)
-        sftp_hook_mock.return_value.get_mod_time.assert_called_with(
+        sftp_hook_mock.return_value.get_mod_time.assert_called_once_with(
             '/path/to/file/1970-01-01.txt')
         self.assertFalse(output)
 
@@ -65,5 +65,5 @@ class TestSFTPSensor(unittest.TestCase):
         }
         with self.assertRaises(OSError):
             sftp_sensor.poke(context)
-            sftp_hook_mock.return_value.get_mod_time.assert_called_with(
+            sftp_hook_mock.return_value.get_mod_time.assert_called_once_with(
                 '/path/to/file/1970-01-01.txt')

--- a/tests/contrib/utils/test_sendgrid.py
+++ b/tests/contrib/utils/test_sendgrid.py
@@ -89,7 +89,7 @@ class TestSendEmailSendGrid(unittest.TestCase):
                        cc=self.cc,
                        bcc=self.bcc,
                        files=[f.name])
-            mock_post.assert_called_with(expected_mail_data)
+            mock_post.assert_called_once_with(expected_mail_data)
 
     # Test the right email is constructed.
     @mock.patch(
@@ -103,11 +103,11 @@ class TestSendEmailSendGrid(unittest.TestCase):
         send_email(self.to, self.subject, self.html_content, cc=self.cc, bcc=self.bcc,
                    personalization_custom_args=self.personalization_custom_args,
                    categories=self.categories)
-        mock_post.assert_called_with(self.expected_mail_data_extras)
+        mock_post.assert_called_once_with(self.expected_mail_data_extras)
 
     @mock.patch('os.environ', {})
     @mock.patch('airflow.contrib.utils.sendgrid._post_sendgrid_mail')
     def test_send_email_sendgrid_sender(self, mock_post):
         send_email(self.to, self.subject, self.html_content, cc=self.cc, bcc=self.bcc,
                    from_email='foo@foo.bar', from_name='Foo Bar')
-        mock_post.assert_called_with(self.expected_mail_data_sender)
+        mock_post.assert_called_once_with(self.expected_mail_data_sender)

--- a/tests/core.py
+++ b/tests/core.py
@@ -2231,14 +2231,14 @@ class TestEmail(unittest.TestCase):
     @mock.patch('airflow.utils.email.send_email')
     def test_default_backend(self, mock_send_email):
         res = utils.email.send_email('to', 'subject', 'content')
-        mock_send_email.assert_called_with('to', 'subject', 'content')
+        mock_send_email.assert_called_once_with('to', 'subject', 'content')
         self.assertEqual(mock_send_email.return_value, res)
 
     @mock.patch('airflow.utils.email.send_email_smtp')
     def test_custom_backend(self, mock_send_email):
         with conf_vars({('email', 'email_backend'): 'tests.core.send_email_test'}):
             utils.email.send_email('to', 'subject', 'content')
-        send_email_test.assert_called_with(
+        send_email_test.assert_called_once_with(
             'to', 'subject', 'content', files=None, dryrun=False,
             cc=None, bcc=None, mime_charset='utf-8', mime_subtype='mixed')
         self.assertFalse(mock_send_email.called)
@@ -2302,16 +2302,16 @@ class TestEmailSmtp(unittest.TestCase):
         mock_smtp_ssl.return_value = mock.Mock()
         msg = MIMEMultipart()
         utils.email.send_MIME_email('from', 'to', msg, dryrun=False)
-        mock_smtp.assert_called_with(
+        mock_smtp.assert_called_once_with(
             configuration.conf.get('smtp', 'SMTP_HOST'),
             configuration.conf.getint('smtp', 'SMTP_PORT'),
         )
         self.assertTrue(mock_smtp.return_value.starttls.called)
-        mock_smtp.return_value.login.assert_called_with(
+        mock_smtp.return_value.login.assert_called_once_with(
             configuration.conf.get('smtp', 'SMTP_USER'),
             configuration.conf.get('smtp', 'SMTP_PASSWORD'),
         )
-        mock_smtp.return_value.sendmail.assert_called_with('from', 'to', msg.as_string())
+        mock_smtp.return_value.sendmail.assert_called_once_with('from', 'to', msg.as_string())
         self.assertTrue(mock_smtp.return_value.quit.called)
 
     @mock.patch('smtplib.SMTP_SSL')
@@ -2322,7 +2322,7 @@ class TestEmailSmtp(unittest.TestCase):
         with conf_vars({('smtp', 'smtp_ssl'): 'True'}):
             utils.email.send_MIME_email('from', 'to', MIMEMultipart(), dryrun=False)
         self.assertFalse(mock_smtp.called)
-        mock_smtp_ssl.assert_called_with(
+        mock_smtp_ssl.assert_called_once_with(
             configuration.conf.get('smtp', 'SMTP_HOST'),
             configuration.conf.getint('smtp', 'SMTP_PORT'),
         )
@@ -2338,7 +2338,7 @@ class TestEmailSmtp(unittest.TestCase):
         }):
             utils.email.send_MIME_email('from', 'to', MIMEMultipart(), dryrun=False)
         self.assertFalse(mock_smtp_ssl.called)
-        mock_smtp.assert_called_with(
+        mock_smtp.assert_called_once_with(
             configuration.conf.get('smtp', 'SMTP_HOST'),
             configuration.conf.getint('smtp', 'SMTP_PORT'),
         )

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -783,7 +783,7 @@ class TestKubernetesExecutor(unittest.TestCase):
         key = ('dag_id', 'task_id', 'ex_time', 'try_number2')
         executor._change_state(key, State.SUCCESS, 'pod_id')
         self.assertTrue(executor.event_buffer[key] == State.SUCCESS)
-        mock_delete_pod.assert_called_with('pod_id')
+        mock_delete_pod.assert_called_once_with('pod_id')
 
     @mock.patch('airflow.executors.kubernetes_executor.KubeConfig')
     @mock.patch('airflow.executors.kubernetes_executor.KubernetesJobWatcher')
@@ -796,7 +796,7 @@ class TestKubernetesExecutor(unittest.TestCase):
         key = ('dag_id', 'task_id', 'ex_time', 'try_number3')
         executor._change_state(key, State.FAILED, 'pod_id')
         self.assertTrue(executor.event_buffer[key] == State.FAILED)
-        mock_delete_pod.assert_called_with('pod_id')
+        mock_delete_pod.assert_called_once_with('pod_id')
 
     @mock.patch('airflow.executors.kubernetes_executor.KubeConfig')
     @mock.patch('airflow.executors.kubernetes_executor.KubernetesJobWatcher')

--- a/tests/gcp/hooks/test_dataflow.py
+++ b/tests/gcp/hooks/test_dataflow.py
@@ -180,7 +180,7 @@ class TestDataFlowHook(unittest.TestCase):
         mock_proc.poll = mock_proc_poll
         mock_popen.return_value = mock_proc
         dataflow = _Dataflow(['test', 'cmd'])
-        mock_logging.info.assert_called_with('Running command: %s', 'test cmd')
+        mock_logging.info.assert_called_once_with('Running command: %s', 'test cmd')
         self.assertRaises(Exception, dataflow.wait_for_done)
 
     def test_valid_dataflow_job_name(self):
@@ -311,8 +311,8 @@ class TestDataFlowJob(unittest.TestCase):
             jobs.return_value = mock_jobs
         _DataflowJob(self.mock_dataflow, TEST_PROJECT, TEST_JOB_NAME,
                      TEST_LOCATION, 10, TEST_JOB_ID)
-        mock_jobs.get.assert_called_with(projectId=TEST_PROJECT, location=TEST_LOCATION,
-                                         jobId=TEST_JOB_ID)
+        mock_jobs.get.assert_called_once_with(projectId=TEST_PROJECT, location=TEST_LOCATION,
+                                              jobId=TEST_JOB_ID)
 
     def test_dataflow_job_init_without_job_id(self):
         mock_jobs = MagicMock()
@@ -320,8 +320,8 @@ class TestDataFlowJob(unittest.TestCase):
             jobs.return_value = mock_jobs
         _DataflowJob(self.mock_dataflow, TEST_PROJECT, TEST_JOB_NAME,
                      TEST_LOCATION, 10)
-        mock_jobs.list.assert_called_with(projectId=TEST_PROJECT,
-                                          location=TEST_LOCATION)
+        mock_jobs.list.assert_called_once_with(projectId=TEST_PROJECT,
+                                               location=TEST_LOCATION)
 
 
 class TestDataflow(unittest.TestCase):

--- a/tests/gcp/hooks/test_functions.py
+++ b/tests/gcp/hooks/test_functions.py
@@ -113,7 +113,7 @@ class TestFunctionHookNoDefaultProjectId(unittest.TestCase):
                 zip_path="/tmp/path.zip"
             )
             self.assertEqual("http://uploadHere", res)
-            generate_upload_url_method.assert_called_with(
+            generate_upload_url_method.assert_called_once_with(
                 parent='projects/example-project/locations/location')
             execute_method.assert_called_once_with(num_retries=5)
             requests_put.assert_called_once_with(
@@ -233,7 +233,7 @@ class TestFunctionHookDefaultProjectId(unittest.TestCase):
                 zip_path="/tmp/path.zip"
             )
             self.assertEqual("http://uploadHere", res)
-            generate_upload_url_method.assert_called_with(
+            generate_upload_url_method.assert_called_once_with(
                 parent='projects/example-project/locations/location')
             execute_method.assert_called_once_with(num_retries=5)
             requests_put.assert_called_once_with(
@@ -259,7 +259,7 @@ class TestFunctionHookDefaultProjectId(unittest.TestCase):
                 zip_path="/tmp/path.zip"
             )
             self.assertEqual("http://uploadHere", res)
-            generate_upload_url_method.assert_called_with(
+            generate_upload_url_method.assert_called_once_with(
                 parent='projects/new-project/locations/location')
             execute_method.assert_called_once_with(num_retries=5)
             requests_put.assert_called_once_with(

--- a/tests/gcp/hooks/test_kms.py
+++ b/tests/gcp/hooks/test_kms.py
@@ -63,9 +63,8 @@ class TestGoogleCloudKMSHook(unittest.TestCase):
         execute_method.return_value = response
 
         ret_val = self.kms_hook.encrypt(TEST_KEY_ID, plaintext)
-        encrypt_method.assert_called_with(name=TEST_KEY_ID,
-                                          body=body)
-        execute_method.assert_called_with(num_retries=mock.ANY)
+        encrypt_method.assert_called_once_with(name=TEST_KEY_ID, body=body)
+        execute_method.assert_called_once_with(num_retries=mock.ANY)
         self.assertEqual(ciphertext, ret_val)
 
     @mock.patch(KMS_STRING.format('GoogleCloudKMSHook.get_conn'))
@@ -92,9 +91,8 @@ class TestGoogleCloudKMSHook(unittest.TestCase):
 
         ret_val = self.kms_hook.encrypt(TEST_KEY_ID, plaintext,
                                         authenticated_data=auth_data)
-        encrypt_method.assert_called_with(name=TEST_KEY_ID,
-                                          body=body)
-        execute_method.assert_called_with(num_retries=mock.ANY)
+        encrypt_method.assert_called_once_with(name=TEST_KEY_ID, body=body)
+        execute_method.assert_called_once_with(num_retries=mock.ANY)
         self.assertEqual(ciphertext, ret_val)
 
     @mock.patch(KMS_STRING.format('GoogleCloudKMSHook.get_conn'))
@@ -115,9 +113,8 @@ class TestGoogleCloudKMSHook(unittest.TestCase):
         execute_method.return_value = response
 
         ret_val = self.kms_hook.decrypt(TEST_KEY_ID, ciphertext)
-        decrypt_method.assert_called_with(name=TEST_KEY_ID,
-                                          body=body)
-        execute_method.assert_called_with(num_retries=mock.ANY)
+        decrypt_method.assert_called_once_with(name=TEST_KEY_ID, body=body)
+        execute_method.assert_called_once_with(num_retries=mock.ANY)
         self.assertEqual(plaintext, ret_val)
 
     @mock.patch(KMS_STRING.format('GoogleCloudKMSHook.get_conn'))
@@ -144,7 +141,6 @@ class TestGoogleCloudKMSHook(unittest.TestCase):
 
         ret_val = self.kms_hook.decrypt(TEST_KEY_ID, ciphertext,
                                         authenticated_data=auth_data)
-        decrypt_method.assert_called_with(name=TEST_KEY_ID,
-                                          body=body)
-        execute_method.assert_called_with(num_retries=mock.ANY)
+        decrypt_method.assert_called_once_with(name=TEST_KEY_ID, body=body)
+        execute_method.assert_called_once_with(num_retries=mock.ANY)
         self.assertEqual(plaintext, ret_val)

--- a/tests/gcp/hooks/test_kubernetes_engine.py
+++ b/tests/gcp/hooks/test_kubernetes_engine.py
@@ -47,12 +47,12 @@ class TestGKEClusterHookDelete(unittest.TestCase):
                                      retry=retry_mock,
                                      timeout=timeout_mock)
 
-        client_delete.assert_called_with(project_id=TEST_GCP_PROJECT_ID,
-                                         zone=GKE_ZONE,
-                                         cluster_id=CLUSTER_NAME,
-                                         retry=retry_mock,
-                                         timeout=timeout_mock)
-        wait_mock.assert_called_with(client_delete.return_value)
+        client_delete.assert_called_once_with(project_id=TEST_GCP_PROJECT_ID,
+                                              zone=GKE_ZONE,
+                                              cluster_id=CLUSTER_NAME,
+                                              retry=retry_mock,
+                                              timeout=timeout_mock)
+        wait_mock.assert_called_once_with(client_delete.return_value)
         convert_mock.assert_not_called()
 
     @mock.patch(
@@ -107,11 +107,11 @@ class TestGKEClusterHookCreate(unittest.TestCase):
                                      retry=retry_mock,
                                      timeout=timeout_mock)
 
-        client_create.assert_called_with(project_id=TEST_GCP_PROJECT_ID,
-                                         zone=GKE_ZONE,
-                                         cluster=mock_cluster_proto,
-                                         retry=retry_mock, timeout=timeout_mock)
-        wait_mock.assert_called_with(client_create.return_value)
+        client_create.assert_called_once_with(project_id=TEST_GCP_PROJECT_ID,
+                                              zone=GKE_ZONE,
+                                              cluster=mock_cluster_proto,
+                                              retry=retry_mock, timeout=timeout_mock)
+        wait_mock.assert_called_once_with(client_create.return_value)
         convert_mock.assert_not_called()
 
     @mock.patch("airflow.gcp.hooks.kubernetes_engine.GKEClusterHook._dict_to_proto")
@@ -129,11 +129,11 @@ class TestGKEClusterHookCreate(unittest.TestCase):
                                      retry=retry_mock,
                                      timeout=timeout_mock)
 
-        client_create.assert_called_with(project_id=TEST_GCP_PROJECT_ID,
-                                         zone=GKE_ZONE,
-                                         cluster=proto_mock,
-                                         retry=retry_mock, timeout=timeout_mock)
-        wait_mock.assert_called_with(client_create.return_value)
+        client_create.assert_called_once_with(project_id=TEST_GCP_PROJECT_ID,
+                                              zone=GKE_ZONE,
+                                              cluster=proto_mock,
+                                              retry=retry_mock, timeout=timeout_mock)
+        wait_mock.assert_called_once_with(client_create.return_value)
         self.assertEqual(convert_mock.call_args[1]['py_dict'], mock_cluster_dict)
 
     @mock.patch("airflow.gcp.hooks.kubernetes_engine.GKEClusterHook._dict_to_proto")
@@ -180,10 +180,10 @@ class TestGKEClusterHookGet(unittest.TestCase):
                                   retry=retry_mock,
                                   timeout=timeout_mock)
 
-        client_get.assert_called_with(project_id=TEST_GCP_PROJECT_ID,
-                                      zone=GKE_ZONE,
-                                      cluster_id=CLUSTER_NAME,
-                                      retry=retry_mock, timeout=timeout_mock)
+        client_get.assert_called_once_with(project_id=TEST_GCP_PROJECT_ID,
+                                           zone=GKE_ZONE,
+                                           cluster_id=CLUSTER_NAME,
+                                           retry=retry_mock, timeout=timeout_mock)
 
 
 class TestGKEClusterHook(unittest.TestCase):
@@ -200,14 +200,14 @@ class TestGKEClusterHook(unittest.TestCase):
         self.gke_hook._client = None
         self.gke_hook.get_client()
         assert mock_get_credentials.called
-        mock_client.assert_called_with(
+        mock_client.assert_called_once_with(
             credentials=mock_get_credentials.return_value,
             client_info=mock_client_info.return_value)
 
     def test_get_operation(self):
         self.gke_hook._client.get_operation = mock.Mock()
         self.gke_hook.get_operation('TEST_OP', project_id=TEST_GCP_PROJECT_ID)
-        self.gke_hook._client.get_operation.assert_called_with(
+        self.gke_hook._client.get_operation.assert_called_once_with(
             project_id=TEST_GCP_PROJECT_ID, zone=GKE_ZONE, operation_id='TEST_OP')
 
     def test_append_label(self):
@@ -215,14 +215,14 @@ class TestGKEClusterHook(unittest.TestCase):
         val = 'test-val'
         mock_proto = mock.Mock()
         self.gke_hook._append_label(mock_proto, key, val)
-        mock_proto.resource_labels.update.assert_called_with({key: val})
+        mock_proto.resource_labels.update.assert_called_once_with({key: val})
 
     def test_append_label_replace(self):
         key = 'test-key'
         val = 'test.val+this'
         mock_proto = mock.Mock()
         self.gke_hook._append_label(mock_proto, key, val)
-        mock_proto.resource_labels.update.assert_called_with({key: 'test-val-this'})
+        mock_proto.resource_labels.update.assert_called_once_with({key: 'test-val-this'})
 
     @mock.patch("time.sleep")
     def test_wait_for_response_done(self, time_mock):
@@ -273,5 +273,5 @@ class TestGKEClusterHook(unittest.TestCase):
 
         self.gke_hook._dict_to_proto(mock_dict, mock_proto)
 
-        dumps_mock.assert_called_with(mock_dict)
-        parse_mock.assert_called_with(dumps_mock(), mock_proto)
+        dumps_mock.assert_called_once_with(mock_dict)
+        parse_mock.assert_called_once_with(dumps_mock(), mock_proto)

--- a/tests/gcp/hooks/test_pubsub.py
+++ b/tests/gcp/hooks/test_pubsub.py
@@ -62,8 +62,8 @@ class TestPubSubHook(unittest.TestCase):
 
         create_method = (mock_service.return_value.projects.return_value.topics
                          .return_value.create)
-        create_method.assert_called_with(body={}, name=EXPANDED_TOPIC)
-        create_method.return_value.execute.assert_called_with(num_retries=mock.ANY)
+        create_method.assert_called_once_with(body={}, name=EXPANDED_TOPIC)
+        create_method.return_value.execute.assert_called_once_with(num_retries=mock.ANY)
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
     def test_delete_topic(self, mock_service):
@@ -71,8 +71,8 @@ class TestPubSubHook(unittest.TestCase):
 
         delete_method = (mock_service.return_value.projects.return_value.topics
                          .return_value.delete)
-        delete_method.assert_called_with(topic=EXPANDED_TOPIC)
-        delete_method.return_value.execute.assert_called_with(num_retries=mock.ANY)
+        delete_method.assert_called_once_with(topic=EXPANDED_TOPIC)
+        delete_method.return_value.execute.assert_called_once_with(num_retries=mock.ANY)
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
     def test_delete_nonexisting_topic_failifnotexists(self, mock_service):
@@ -117,9 +117,8 @@ class TestPubSubHook(unittest.TestCase):
             'topic': EXPANDED_TOPIC,
             'ackDeadlineSeconds': 10
         }
-        create_method.assert_called_with(name=EXPANDED_SUBSCRIPTION,
-                                         body=expected_body)
-        create_method.return_value.execute.assert_called_with(num_retries=mock.ANY)
+        create_method.assert_called_once_with(name=EXPANDED_SUBSCRIPTION, body=expected_body)
+        create_method.return_value.execute.assert_called_once_with(num_retries=mock.ANY)
         self.assertEqual(TEST_SUBSCRIPTION, response)
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
@@ -137,9 +136,8 @@ class TestPubSubHook(unittest.TestCase):
             'topic': EXPANDED_TOPIC,
             'ackDeadlineSeconds': 10
         }
-        create_method.assert_called_with(name=expected_subscription,
-                                         body=expected_body)
-        create_method.return_value.execute.assert_called_with(num_retries=mock.ANY)
+        create_method.assert_called_once_with(name=expected_subscription, body=expected_body)
+        create_method.return_value.execute.assert_called_once_with(num_retries=mock.ANY)
         self.assertEqual(TEST_SUBSCRIPTION, response)
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
@@ -148,8 +146,8 @@ class TestPubSubHook(unittest.TestCase):
 
         delete_method = (mock_service.return_value.projects
                          .return_value.subscriptions.return_value.delete)
-        delete_method.assert_called_with(subscription=EXPANDED_SUBSCRIPTION)
-        delete_method.return_value.execute.assert_called_with(num_retries=mock.ANY)
+        delete_method.assert_called_once_with(subscription=EXPANDED_SUBSCRIPTION)
+        delete_method.return_value.execute.assert_called_once_with(num_retries=mock.ANY)
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
     def test_delete_nonexisting_subscription_failifnotexists(self,
@@ -181,9 +179,8 @@ class TestPubSubHook(unittest.TestCase):
         }
         expected_name = EXPANDED_SUBSCRIPTION.replace(
             TEST_SUBSCRIPTION, 'sub-%s' % TEST_UUID)
-        create_method.assert_called_with(name=expected_name,
-                                         body=expected_body)
-        create_method.return_value.execute.assert_called_with(num_retries=mock.ANY)
+        create_method.assert_called_once_with(name=expected_name, body=expected_body)
+        create_method.return_value.execute.assert_called_once_with(num_retries=mock.ANY)
         self.assertEqual('sub-%s' % TEST_UUID, response)
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
@@ -198,9 +195,8 @@ class TestPubSubHook(unittest.TestCase):
             'topic': EXPANDED_TOPIC,
             'ackDeadlineSeconds': 30
         }
-        create_method.assert_called_with(name=EXPANDED_SUBSCRIPTION,
-                                         body=expected_body)
-        create_method.return_value.execute.assert_called_with(num_retries=mock.ANY)
+        create_method.assert_called_once_with(name=EXPANDED_SUBSCRIPTION, body=expected_body)
+        create_method.return_value.execute.assert_called_once_with(num_retries=mock.ANY)
         self.assertEqual(TEST_SUBSCRIPTION, response)
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
@@ -236,7 +232,7 @@ class TestPubSubHook(unittest.TestCase):
 
         publish_method = (mock_service.return_value.projects.return_value
                           .topics.return_value.publish)
-        publish_method.assert_called_with(
+        publish_method.assert_called_once_with(
             topic=EXPANDED_TOPIC, body={'messages': TEST_MESSAGES})
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
@@ -250,7 +246,7 @@ class TestPubSubHook(unittest.TestCase):
             'receivedMessages': pulled_messages}
 
         response = self.pubsub_hook.pull(TEST_PROJECT, TEST_SUBSCRIPTION, 10)
-        pull_method.assert_called_with(
+        pull_method.assert_called_once_with(
             subscription=EXPANDED_SUBSCRIPTION,
             body={'maxMessages': 10, 'returnImmediately': False})
         self.assertEqual(pulled_messages, response)
@@ -263,7 +259,7 @@ class TestPubSubHook(unittest.TestCase):
             'receivedMessages': []}
 
         response = self.pubsub_hook.pull(TEST_PROJECT, TEST_SUBSCRIPTION, 10)
-        pull_method.assert_called_with(
+        pull_method.assert_called_once_with(
             subscription=EXPANDED_SUBSCRIPTION,
             body={'maxMessages': 10, 'returnImmediately': False})
         self.assertListEqual([], response)
@@ -277,7 +273,7 @@ class TestPubSubHook(unittest.TestCase):
 
         with self.assertRaises(Exception):
             self.pubsub_hook.pull(TEST_PROJECT, TEST_SUBSCRIPTION, 10)
-            pull_method.assert_called_with(
+            pull_method.assert_called_once_with(
                 subscription=EXPANDED_SUBSCRIPTION,
                 body={'maxMessages': 10, 'returnImmediately': False})
 
@@ -287,7 +283,7 @@ class TestPubSubHook(unittest.TestCase):
                       .subscriptions.return_value.acknowledge)
         self.pubsub_hook.acknowledge(
             TEST_PROJECT, TEST_SUBSCRIPTION, ['1', '2', '3'])
-        ack_method.assert_called_with(
+        ack_method.assert_called_once_with(
             subscription=EXPANDED_SUBSCRIPTION,
             body={'ackIds': ['1', '2', '3']})
 
@@ -301,7 +297,7 @@ class TestPubSubHook(unittest.TestCase):
         with self.assertRaises(Exception) as e:
             self.pubsub_hook.acknowledge(
                 TEST_PROJECT, TEST_SUBSCRIPTION, ['1', '2', '3'])
-            ack_method.assert_called_with(
+            ack_method.assert_called_once_with(
                 subscription=EXPANDED_SUBSCRIPTION,
                 body={'ackIds': ['1', '2', '3']})
             print(e)

--- a/tests/gcp/hooks/test_spanner.py
+++ b/tests/gcp/hooks/test_spanner.py
@@ -112,7 +112,7 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         instance_method.assert_called_once_with(
             instance_id='instance', configuration_name='configuration', display_name='database-name',
             node_count=2)
-        update_method.assert_called_with()
+        update_method.assert_called_once_with()
         self.assertIsNone(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -132,7 +132,7 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         instance_method.assert_called_once_with(
             instance_id='instance', configuration_name='configuration', display_name='database-name',
             node_count=2)
-        update_method.assert_called_with()
+        update_method.assert_called_once_with()
         self.assertIsNone(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -147,7 +147,7 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         get_client.assert_called_once_with(project_id='example-project')
         instance_method.assert_called_once_with(
             'instance')
-        delete_method.assert_called_with()
+        delete_method.assert_called_once_with()
         self.assertIsNone(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -163,7 +163,7 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         get_client.assert_called_once_with(project_id='new-project')
         instance_method.assert_called_once_with(
             'instance')
-        delete_method.assert_called_with()
+        delete_method.assert_called_once_with()
         self.assertIsNone(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -179,8 +179,8 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
             database_id=SPANNER_DATABASE)
         get_client.assert_called_once_with(project_id='example-project')
         instance_method.assert_called_once_with(instance_id='instance')
-        database_method.assert_called_with(database_id='database-name')
-        database_exists_method.assert_called_with()
+        database_method.assert_called_once_with(database_id='database-name')
+        database_exists_method.assert_called_once_with()
         self.assertIsNotNone(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -197,8 +197,8 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
             database_id=SPANNER_DATABASE)
         get_client.assert_called_once_with(project_id='new-project')
         instance_method.assert_called_once_with(instance_id='instance')
-        database_method.assert_called_with(database_id='database-name')
-        database_exists_method.assert_called_with()
+        database_method.assert_called_once_with(database_id='database-name')
+        database_exists_method.assert_called_once_with()
         self.assertIsNotNone(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -214,8 +214,8 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
             ddl_statements=[])
         get_client.assert_called_once_with(project_id='example-project')
         instance_method.assert_called_once_with(instance_id='instance')
-        database_method.assert_called_with(database_id='database-name', ddl_statements=[])
-        database_create_method.assert_called_with()
+        database_method.assert_called_once_with(database_id='database-name', ddl_statements=[])
+        database_create_method.assert_called_once_with()
         self.assertIsNone(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -232,8 +232,8 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
             ddl_statements=[])
         get_client.assert_called_once_with(project_id='new-project')
         instance_method.assert_called_once_with(instance_id='instance')
-        database_method.assert_called_with(database_id='database-name', ddl_statements=[])
-        database_create_method.assert_called_with()
+        database_method.assert_called_once_with(database_id='database-name', ddl_statements=[])
+        database_create_method.assert_called_once_with()
         self.assertIsNone(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -249,8 +249,8 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
             ddl_statements=[])
         get_client.assert_called_once_with(project_id='example-project')
         instance_method.assert_called_once_with(instance_id='instance')
-        database_method.assert_called_with(database_id='database-name')
-        database_update_ddl_method.assert_called_with(ddl_statements=[], operation_id=None)
+        database_method.assert_called_once_with(database_id='database-name')
+        database_update_ddl_method.assert_called_once_with(ddl_statements=[], operation_id=None)
         self.assertIsNone(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -267,8 +267,8 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
             ddl_statements=[])
         get_client.assert_called_once_with(project_id='new-project')
         instance_method.assert_called_once_with(instance_id='instance')
-        database_method.assert_called_with(database_id='database-name')
-        database_update_ddl_method.assert_called_with(ddl_statements=[], operation_id=None)
+        database_method.assert_called_once_with(database_id='database-name')
+        database_update_ddl_method.assert_called_once_with(ddl_statements=[], operation_id=None)
         self.assertIsNone(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -285,9 +285,9 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
             database_id=SPANNER_DATABASE)
         get_client.assert_called_once_with(project_id='example-project')
         instance_method.assert_called_once_with(instance_id='instance')
-        database_method.assert_called_with(database_id='database-name')
-        database_exists_method.assert_called_with()
-        database_drop_method.assert_called_with()
+        database_method.assert_called_once_with(database_id='database-name')
+        database_exists_method.assert_called_once_with()
+        database_drop_method.assert_called_once_with()
         self.assertTrue(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -305,9 +305,9 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
             database_id=SPANNER_DATABASE)
         get_client.assert_called_once_with(project_id='new-project')
         instance_method.assert_called_once_with(instance_id='instance')
-        database_method.assert_called_with(database_id='database-name')
-        database_exists_method.assert_called_with()
-        database_drop_method.assert_called_with()
+        database_method.assert_called_once_with(database_id='database-name')
+        database_exists_method.assert_called_once_with()
+        database_drop_method.assert_called_once_with()
         self.assertTrue(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -323,8 +323,8 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
             queries='')
         get_client.assert_called_once_with(project_id='example-project')
         instance_method.assert_called_once_with(instance_id='instance')
-        database_method.assert_called_with(database_id='database-name')
-        run_in_transaction_method.assert_called_with(mock.ANY)
+        database_method.assert_called_once_with(database_id='database-name')
+        run_in_transaction_method.assert_called_once_with(mock.ANY)
         self.assertIsNone(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -341,8 +341,8 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
             queries='')
         get_client.assert_called_once_with(project_id='new-project')
         instance_method.assert_called_once_with(instance_id='instance')
-        database_method.assert_called_with(database_id='database-name')
-        run_in_transaction_method.assert_called_with(mock.ANY)
+        database_method.assert_called_once_with(database_id='database-name')
+        run_in_transaction_method.assert_called_once_with(mock.ANY)
         self.assertIsNone(res)
 
 
@@ -461,7 +461,7 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         instance_method.assert_called_once_with(
             instance_id='instance', configuration_name='configuration', display_name='database-name',
             node_count=2)
-        update_method.assert_called_with()
+        update_method.assert_called_once_with()
         self.assertIsNone(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -493,7 +493,7 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         get_client.assert_called_once_with(project_id='example-project')
         instance_method.assert_called_once_with(
             'instance')
-        delete_method.assert_called_with()
+        delete_method.assert_called_once_with()
         self.assertIsNone(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -528,8 +528,8 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
             database_id=SPANNER_DATABASE)
         get_client.assert_called_once_with(project_id='example-project')
         instance_method.assert_called_once_with(instance_id='instance')
-        database_method.assert_called_with(database_id='database-name')
-        database_exists_method.assert_called_with()
+        database_method.assert_called_once_with(database_id='database-name')
+        database_exists_method.assert_called_once_with()
         self.assertIsNotNone(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -565,8 +565,8 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
             ddl_statements=[])
         get_client.assert_called_once_with(project_id='example-project')
         instance_method.assert_called_once_with(instance_id='instance')
-        database_method.assert_called_with(database_id='database-name', ddl_statements=[])
-        database_create_method.assert_called_with()
+        database_method.assert_called_once_with(database_id='database-name', ddl_statements=[])
+        database_create_method.assert_called_once_with()
         self.assertIsNone(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -602,8 +602,8 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
             ddl_statements=[])
         get_client.assert_called_once_with(project_id='example-project')
         instance_method.assert_called_once_with(instance_id='instance')
-        database_method.assert_called_with(database_id='database-name')
-        database_update_ddl_method.assert_called_with(ddl_statements=[], operation_id=None)
+        database_method.assert_called_once_with(database_id='database-name')
+        database_update_ddl_method.assert_called_once_with(ddl_statements=[], operation_id=None)
         self.assertIsNone(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -621,8 +621,8 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
             ddl_statements=[])
         get_client.assert_called_once_with(project_id='example-project')
         instance_method.assert_called_once_with(instance_id='instance')
-        database_method.assert_called_with(database_id='database-name')
-        database_update_ddl_method.assert_called_with(ddl_statements=[], operation_id="operation")
+        database_method.assert_called_once_with(database_id='database-name')
+        database_update_ddl_method.assert_called_once_with(ddl_statements=[], operation_id="operation")
         self.assertIsNone(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -661,9 +661,9 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
             database_id=SPANNER_DATABASE)
         get_client.assert_called_once_with(project_id='example-project')
         instance_method.assert_called_once_with(instance_id='instance')
-        database_method.assert_called_with(database_id='database-name')
-        database_exists_method.assert_called_with()
-        database_drop_method.assert_called_with()
+        database_method.assert_called_once_with(database_id='database-name')
+        database_exists_method.assert_called_once_with()
+        database_drop_method.assert_called_once_with()
         self.assertTrue(res)
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -681,8 +681,8 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
             database_id=SPANNER_DATABASE)
         get_client.assert_called_once_with(project_id='example-project')
         instance_method.assert_called_once_with(instance_id='instance')
-        database_method.assert_called_with(database_id='database-name')
-        database_exists_method.assert_called_with()
+        database_method.assert_called_once_with(database_id='database-name')
+        database_exists_method.assert_called_once_with()
         database_drop_method.assert_not_called()
 
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
@@ -718,6 +718,6 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
             queries='')
         get_client.assert_called_once_with(project_id='example-project')
         instance_method.assert_called_once_with(instance_id='instance')
-        database_method.assert_called_with(database_id='database-name')
-        run_in_transaction_method.assert_called_with(mock.ANY)
+        database_method.assert_called_once_with(database_id='database-name')
+        run_in_transaction_method.assert_called_once_with(mock.ANY)
         self.assertIsNone(res)

--- a/tests/gcp/operators/test_kubernetes_engine.py
+++ b/tests/gcp/operators/test_kubernetes_engine.py
@@ -168,7 +168,7 @@ class TestGKEPodOperator(unittest.TestCase):
         self.assertEqual(os.environ[KUBE_ENV_VAR], FILE_NAME)
 
         # Assert the gcloud command being called correctly
-        proc_mock.assert_called_with(
+        proc_mock.assert_called_once_with(
             GCLOUD_COMMAND.format(CLUSTER_NAME, PROJECT_LOCATION, TEST_GCP_PROJECT_ID).split())
 
         self.assertEqual(self.gke_op.config_file, FILE_NAME)
@@ -199,7 +199,7 @@ class TestGKEPodOperator(unittest.TestCase):
         self.assertEqual(os.environ[CREDENTIALS], file_path)
 
         # Assert the gcloud command being called correctly
-        proc_mock.assert_called_with(
+        proc_mock.assert_called_once_with(
             GCLOUD_COMMAND.format(CLUSTER_NAME, PROJECT_LOCATION, TEST_GCP_PROJECT_ID).split())
 
         self.assertEqual(self.gke_op.config_file, FILE_NAME)
@@ -235,7 +235,7 @@ class TestGKEPodOperator(unittest.TestCase):
         self.assertEqual(os.environ[CREDENTIALS], file_path)
 
         # Assert the gcloud command being called correctly
-        proc_mock.assert_called_with(
+        proc_mock.assert_called_once_with(
             GCLOUD_COMMAND.format(CLUSTER_NAME, PROJECT_LOCATION, TEST_GCP_PROJECT_ID).split())
 
         self.assertEqual(self.gke_op.config_file, FILE_NAME)
@@ -300,4 +300,4 @@ class TestGKEPodOperator(unittest.TestCase):
         ret_val = self.gke_op._get_field(extras, field_name, default=field_value)
         # Assert default is returned upon failure
         self.assertEqual(field_value, ret_val)
-        log_mock.info.assert_called_with(log_str, field_name)
+        log_mock.info.assert_called_once_with(log_str, field_name)

--- a/tests/gcp/operators/test_mlengine.py
+++ b/tests/gcp/operators/test_mlengine.py
@@ -102,7 +102,7 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
                 task_id='test-prediction')
             prediction_output = prediction_task.execute(None)
 
-            mock_hook.assert_called_with('google_cloud_default', None)
+            mock_hook.assert_called_once_with('google_cloud_default', None)
             hook_instance.create_job.assert_called_once_with(
                 'test-project', {
                     'jobId': 'test_prediction',
@@ -141,8 +141,8 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
                 task_id='test-prediction')
             prediction_output = prediction_task.execute(None)
 
-            mock_hook.assert_called_with('google_cloud_default', None)
-            hook_instance.create_job.assert_called_with(
+            mock_hook.assert_called_once_with('google_cloud_default', None)
+            hook_instance.create_job.assert_called_once_with(
                 'test-project', {
                     'jobId': 'test_prediction',
                     'predictionInput': input_with_version
@@ -178,8 +178,8 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
                 task_id='test-prediction')
             prediction_output = prediction_task.execute(None)
 
-            mock_hook.assert_called_with('google_cloud_default', None)
-            hook_instance.create_job.assert_called_with(
+            mock_hook.assert_called_once_with('google_cloud_default', None)
+            hook_instance.create_job.assert_called_once_with(
                 'test-project', {
                     'jobId': 'test_prediction',
                     'predictionInput': input_with_uri
@@ -256,8 +256,8 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
                     task_id='test-prediction')
                 prediction_task.execute(None)
 
-                mock_hook.assert_called_with('google_cloud_default', None)
-                hook_instance.create_job.assert_called_with(
+                mock_hook.assert_called_once_with('google_cloud_default', None)
+                hook_instance.create_job.assert_called_once_with(
                     'test-project', {
                         'jobId': 'test_prediction',
                         'predictionInput': input_with_model
@@ -316,11 +316,11 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
                 **self.TRAINING_DEFAULT_ARGS)
             training_op.execute(None)
 
-            mock_hook.assert_called_with(
+            mock_hook.assert_called_once_with(
                 gcp_conn_id='google_cloud_default', delegate_to=None)
             # Make sure only 'create_job' is invoked on hook instance
             self.assertEqual(len(hook_instance.mock_calls), 1)
-            hook_instance.create_job.assert_called_with(
+            hook_instance.create_job.assert_called_once_with(
                 'test-project', self.TRAINING_INPUT, ANY)
 
     def test_success_create_training_job_with_optional_args(self):
@@ -343,11 +343,10 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
                 **self.TRAINING_DEFAULT_ARGS)
             training_op.execute(None)
 
-            mock_hook.assert_called_with(gcp_conn_id='google_cloud_default',
-                                         delegate_to=None)
+            mock_hook.assert_called_once_with(gcp_conn_id='google_cloud_default', delegate_to=None)
             # Make sure only 'create_job' is invoked on hook instance
             self.assertEqual(len(hook_instance.mock_calls), 1)
-            hook_instance.create_job.assert_called_with(
+            hook_instance.create_job.assert_called_once_with(
                 'test-project', training_input, ANY)
 
     def test_http_error(self):
@@ -366,11 +365,11 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
                     **self.TRAINING_DEFAULT_ARGS)
                 training_op.execute(None)
 
-            mock_hook.assert_called_with(
+            mock_hook.assert_called_once_with(
                 gcp_conn_id='google_cloud_default', delegate_to=None)
             # Make sure only 'create_job' is invoked on hook instance
             self.assertEqual(len(hook_instance.mock_calls), 1)
-            hook_instance.create_job.assert_called_with(
+            hook_instance.create_job.assert_called_once_with(
                 'test-project', self.TRAINING_INPUT, ANY)
             self.assertEqual(http_error_code, context.exception.resp.status)
 
@@ -388,11 +387,11 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
                     **self.TRAINING_DEFAULT_ARGS)
                 training_op.execute(None)
 
-            mock_hook.assert_called_with(
+            mock_hook.assert_called_once_with(
                 gcp_conn_id='google_cloud_default', delegate_to=None)
             # Make sure only 'create_job' is invoked on hook instance
             self.assertEqual(len(hook_instance.mock_calls), 1)
-            hook_instance.create_job.assert_called_with(
+            hook_instance.create_job.assert_called_once_with(
                 'test-project', self.TRAINING_INPUT, ANY)
             self.assertEqual('A failure message', str(context.exception))
 
@@ -421,11 +420,10 @@ class TestMLEngineVersionOperator(unittest.TestCase):
                 **self.VERSION_DEFAULT_ARGS)
             training_op.execute(None)
 
-            mock_hook.assert_called_with(gcp_conn_id='google_cloud_default',
-                                         delegate_to=None)
+            mock_hook.assert_called_once_with(gcp_conn_id='google_cloud_default', delegate_to=None)
             # Make sure only 'create_version' is invoked on hook instance
             self.assertEqual(len(hook_instance.mock_calls), 1)
-            hook_instance.create_version.assert_called_with(
+            hook_instance.create_version.assert_called_once_with(
                 'test-project', 'test-model', self.VERSION_INPUT)
 
 

--- a/tests/gcp/operators/test_mlengine_utils.py
+++ b/tests/gcp/operators/test_mlengine_utils.py
@@ -86,7 +86,7 @@ class TestCreateEvaluateOps(unittest.TestCase):
             hook_instance = mock_mlengine_hook.return_value
             hook_instance.create_job.return_value = success_message
             result = pred.execute(None)
-            mock_mlengine_hook.assert_called_with('google_cloud_default', None)
+            mock_mlengine_hook.assert_called_once_with('google_cloud_default', None)
             hook_instance.create_job.assert_called_once_with(
                 'test-project',
                 {
@@ -100,7 +100,7 @@ class TestCreateEvaluateOps(unittest.TestCase):
             hook_instance = mock_dataflow_hook.return_value
             hook_instance.start_python_dataflow.return_value = None
             summary.execute(None)
-            mock_dataflow_hook.assert_called_with(
+            mock_dataflow_hook.assert_called_once_with(
                 gcp_conn_id='google_cloud_default', delegate_to=None, poll_sleep=10)
             hook_instance.start_python_dataflow.assert_called_once_with(
                 '{{task.task_id}}',

--- a/tests/gcp/sensors/test_cloud_storage_transfer_service.py
+++ b/tests/gcp/sensors/test_cloud_storage_transfer_service.py
@@ -43,10 +43,10 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor(unittest.TestCase):
         context = {'ti': (mock.Mock(**{'xcom_push.return_value': None}))}
         result = op.poke(context)
 
-        mock_tool.return_value.list_transfer_operations.assert_called_with(
+        mock_tool.return_value.list_transfer_operations.assert_called_once_with(
             request_filter={'project_id': 'project-id', 'job_names': ['job-name']}
         )
-        mock_tool.operations_contain_expected_statuses.assert_called_with(
+        mock_tool.operations_contain_expected_statuses.assert_called_once_with(
             operations=operations, expected_statuses={GcpTransferOperationStatus.SUCCESS}
         )
         self.assertTrue(result)
@@ -66,7 +66,7 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor(unittest.TestCase):
 
         result = op.poke(context)
 
-        mock_tool.operations_contain_expected_statuses.assert_called_with(
+        mock_tool.operations_contain_expected_statuses.assert_called_once_with(
             operations=mock.ANY, expected_statuses={GcpTransferOperationStatus.SUCCESS}
         )
         self.assertTrue(result)
@@ -94,7 +94,7 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor(unittest.TestCase):
         result = op.poke(context)
         self.assertFalse(result)
 
-        mock_tool.operations_contain_expected_statuses.assert_called_with(
+        mock_tool.operations_contain_expected_statuses.assert_called_once_with(
             operations=operations_set[0], expected_statuses={GcpTransferOperationStatus.SUCCESS}
         )
         mock_tool.operations_contain_expected_statuses.reset_mock()
@@ -102,7 +102,7 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor(unittest.TestCase):
         result = op.poke(context)
         self.assertTrue(result)
 
-        mock_tool.operations_contain_expected_statuses.assert_called_with(
+        mock_tool.operations_contain_expected_statuses.assert_called_once_with(
             operations=operations_set[1], expected_statuses={GcpTransferOperationStatus.SUCCESS}
         )
 
@@ -136,6 +136,6 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor(unittest.TestCase):
         result = op.poke(context)
         self.assertFalse(result)
 
-        mock_tool.operations_contain_expected_statuses.assert_called_with(
+        mock_tool.operations_contain_expected_statuses.assert_called_once_with(
             operations=operations, expected_statuses=received_status
         )

--- a/tests/gcp/sensors/test_pubsub.py
+++ b/tests/gcp/sensors/test_pubsub.py
@@ -67,7 +67,7 @@ class TestPubSubPullSensor(unittest.TestCase):
         generated_messages = self._generate_messages(5)
         mock_hook.return_value.pull.return_value = generated_messages
         self.assertEqual(generated_messages, operator.poke(None))
-        mock_hook.return_value.acknowledge.assert_called_with(
+        mock_hook.return_value.acknowledge.assert_called_once_with(
             TEST_PROJECT, TEST_SUBSCRIPTION, ['1', '2', '3', '4', '5']
         )
 
@@ -79,7 +79,7 @@ class TestPubSubPullSensor(unittest.TestCase):
         generated_messages = self._generate_messages(5)
         mock_hook.return_value.pull.return_value = generated_messages
         response = operator.execute(None)
-        mock_hook.return_value.pull.assert_called_with(
+        mock_hook.return_value.pull.assert_called_once_with(
             TEST_PROJECT, TEST_SUBSCRIPTION, 5, False)
         self.assertEqual(response, generated_messages)
 
@@ -91,5 +91,5 @@ class TestPubSubPullSensor(unittest.TestCase):
         mock_hook.return_value.pull.return_value = []
         with self.assertRaises(AirflowSensorTimeout):
             operator.execute(None)
-            mock_hook.return_value.pull.assert_called_with(
+            mock_hook.return_value.pull.assert_called_once_with(
                 TEST_PROJECT, TEST_SUBSCRIPTION, 5, False)

--- a/tests/hooks/test_docker_hook.py
+++ b/tests/hooks/test_docker_hook.py
@@ -78,7 +78,7 @@ class TestDockerHook(unittest.TestCase):
             tls='someconfig'
         )
         hook.get_conn()
-        docker_client_mock.assert_called_with(
+        docker_client_mock.assert_called_once_with(
             base_url='https://index.docker.io/v1/',
             version='1.23',
             tls='someconfig'
@@ -115,7 +115,7 @@ class TestDockerHook(unittest.TestCase):
             version='auto'
         )
         client = hook.get_conn()
-        client.login.assert_called_with(
+        client.login.assert_called_once_with(
             username='some_user',
             password='some_p4$$w0rd',
             registry='some.docker.registry.com',
@@ -130,7 +130,7 @@ class TestDockerHook(unittest.TestCase):
             version='auto'
         )
         client = hook.get_conn()
-        client.login.assert_called_with(
+        client.login.assert_called_once_with(
             username='some_user',
             password='some_p4$$w0rd',
             registry='another.docker.registry.com:9876',

--- a/tests/hooks/test_hive_hook.py
+++ b/tests/hooks/test_hive_hook.py
@@ -138,7 +138,11 @@ class TestHiveCliHook(unittest.TestCase):
             "OVERWRITE INTO TABLE {table} ;\n"
             .format(filepath=filepath, table=table)
         )
-        mock_run_cli.assert_called_with(query)
+        calls = [
+            mock.call(';'),
+            mock.call(query)
+        ]
+        mock_run_cli.assert_has_calls(calls, any_order=True)
 
     @mock.patch('airflow.hooks.hive_hooks.HiveCliHook.load_file')
     @mock.patch('pandas.DataFrame.to_csv')
@@ -415,7 +419,7 @@ class TestHiveServer2Hook(unittest.TestCase):
         os.environ[conn_env] = "jdbc+hive2://conn_id:conn_pass@localhost:10000/default?authMechanism=LDAP"
 
         HiveServer2Hook(hiveserver2_conn_id=conn_id).get_conn()
-        mock_connect.assert_called_with(
+        mock_connect.assert_called_once_with(
             host='localhost',
             port=10000,
             auth='LDAP',

--- a/tests/hooks/test_mysql_hook.py
+++ b/tests/hooks/test_mysql_hook.py
@@ -195,7 +195,11 @@ class TestMySqlHook(unittest.TestCase):
             self.assertEqual(len(args), 1)
             self.assertEqual(args[0], sql[i])
             self.assertEqual(kwargs, {})
-        self.cur.execute.assert_called_with(sql[1])
+        calls = [
+            mock.call(sql[0]),
+            mock.call(sql[1])
+        ]
+        self.cur.execute.assert_has_calls(calls, any_order=True)
         self.conn.commit.assert_not_called()
 
     def test_bulk_load(self):

--- a/tests/hooks/test_oracle_hook.py
+++ b/tests/hooks/test_oracle_hook.py
@@ -237,9 +237,16 @@ class TestOracleHook(unittest.TestCase):
         rows = [(1, 2, 3), (4, 5, 6), (7, 8, 9)]
         target_fields = ['col1', 'col2', 'col3']
         self.db_hook.bulk_insert_rows('table', rows, target_fields, commit_every=2)
-        self.cur.prepare.assert_called_with(
-            "insert into table (col1, col2, col3) values (:1, :2, :3)")
-        self.cur.executemany.assert_called_with(None, rows[2:])
+        calls = [
+            mock.call("insert into table (col1, col2, col3) values (:1, :2, :3)"),
+            mock.call("insert into table (col1, col2, col3) values (:1, :2, :3)"),
+        ]
+        self.cur.prepare.assert_has_calls(calls)
+        calls = [
+            mock.call(None, rows[:2]),
+            mock.call(None, rows[2:]),
+        ]
+        self.cur.executemany.assert_has_calls(calls, any_order=True)
 
     def test_bulk_insert_rows_without_fields(self):
         rows = [(1, 2, 3), (4, 5, 6), (7, 8, 9)]

--- a/tests/hooks/test_pig_hook.py
+++ b/tests/hooks/test_pig_hook.py
@@ -41,7 +41,7 @@ class TestPigCliHook(unittest.TestCase):
 
     def test_init(self):
         self.pig_hook()
-        self.extra_dejson.get.assert_called_with('pig_properties', '')
+        self.extra_dejson.get.assert_called_once_with('pig_properties', '')
 
     @mock.patch('subprocess.Popen')
     def test_run_cli_success(self, popen_mock):

--- a/tests/hooks/test_slack_hook.py
+++ b/tests/hooks/test_slack_hook.py
@@ -38,7 +38,7 @@ class TestSlackHook(unittest.TestCase):
         test_slack_conn_id = 'test_slack_conn_id'
         slack_hook = SlackHook(token=None, slack_conn_id=test_slack_conn_id)
 
-        get_connection_mock.assert_called_with(test_slack_conn_id)
+        get_connection_mock.assert_called_once_with(test_slack_conn_id)
         self.assertEqual(slack_hook.token, test_password)
 
     @mock.patch('airflow.hooks.slack_hook.SlackHook.get_connection')
@@ -81,8 +81,8 @@ class TestSlackHook(unittest.TestCase):
 
         slack_hook.call(test_method, test_api_params)
 
-        slack_client_class_mock.assert_called_with(test_token)
-        slack_client_mock.api_call.assert_called_with(test_method, **test_api_params)
+        slack_client_class_mock.assert_called_once_with(test_token)
+        slack_client_mock.api_call.assert_called_once_with(test_method, **test_api_params)
 
     @mock.patch('airflow.hooks.slack_hook.SlackClient')
     def test_call_with_failure(self, slack_client_class_mock):

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1396,7 +1396,7 @@ class TestSchedulerJob(unittest.TestCase):
         mock_list = Mock()
         scheduler._process_task_instances(dag, task_instances_list=mock_list)
 
-        mock_list.append.assert_called_with(
+        mock_list.append.assert_called_once_with(
             (dag.dag_id, dag_task1.task_id, DEFAULT_DATE, TRY_NUMBER)
         )
 
@@ -1681,7 +1681,7 @@ class TestSchedulerJob(unittest.TestCase):
         # tasks are put on the task_instances_list (should be one, not 3)
         scheduler._process_task_instances(dag, task_instances_list=task_instances_list)
 
-        task_instances_list.append.assert_called_with(
+        task_instances_list.append.assert_called_once_with(
             (dag.dag_id, dag_task1.task_id, DEFAULT_DATE, TRY_NUMBER)
         )
 
@@ -1987,7 +1987,7 @@ class TestSchedulerJob(unittest.TestCase):
                         new_callable=PropertyMock) as mock_log:
             scheduler.manage_slas(dag=dag, session=session)
             assert sla_callback.called
-            mock_log().exception.assert_called_with(
+            mock_log().exception.assert_called_once_with(
                 'Could not call sla_miss_callback for DAG %s',
                 'test_sla_miss')
 
@@ -2028,7 +2028,7 @@ class TestSchedulerJob(unittest.TestCase):
         with mock.patch('airflow.jobs.SchedulerJob.log',
                         new_callable=PropertyMock) as mock_log:
             scheduler.manage_slas(dag=dag, session=session)
-            mock_log().exception.assert_called_with(
+            mock_log().exception.assert_called_once_with(
                 'Could not send SLA Miss email notification for DAG %s',
                 'test_sla_miss')
 

--- a/tests/minikube/test_kubernetes_pod_operator.py
+++ b/tests/minikube/test_kubernetes_pod_operator.py
@@ -82,9 +82,11 @@ class TestKubernetesPodOperator(unittest.TestCase):
         )
         launcher_mock.return_value = (State.SUCCESS, None)
         k.execute(None)
-        client_mock.assert_called_with(in_cluster=False,
-                                       cluster_context='default',
-                                       config_file=file_path)
+        client_mock.assert_called_once_with(
+            in_cluster=False,
+            cluster_context='default',
+            config_file=file_path
+        )
 
     @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.run_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -623,11 +623,11 @@ class TestDagBag(unittest.TestCase):
             session.commit()
 
             dagbag.kill_zombies()
-            mock_ti_handle_failure \
-                .assert_called_with(ANY,
-                                    configuration.getboolean('core',
-                                                             'unit_test_mode'),
-                                    ANY)
+            mock_ti_handle_failure.assert_called_once_with(
+                ANY,
+                configuration.getboolean('core', 'unit_test_mode'),
+                ANY
+            )
 
     @patch.object(TI, 'handle_failure')
     def test_kill_zombie_when_job_received_no_heartbeat(self, mock_ti_handle_failure):
@@ -655,11 +655,11 @@ class TestDagBag(unittest.TestCase):
             session.commit()
 
             dagbag.kill_zombies()
-            mock_ti_handle_failure \
-                .assert_called_with(ANY,
-                                    configuration.getboolean('core',
-                                                             'unit_test_mode'),
-                                    ANY)
+            mock_ti_handle_failure.assert_called_once_with(
+                ANY,
+                configuration.getboolean('core', 'unit_test_mode'),
+                ANY
+            )
 
     @patch.object(TI, 'handle_failure')
     def test_kill_zombies_doesn_nothing(self, mock_ti_handle_failure):

--- a/tests/operators/test_check_operator.py
+++ b/tests/operators/test_check_operator.py
@@ -88,7 +88,7 @@ class TestValueCheckOperator(unittest.TestCase):
 
         operator.execute(None)
 
-        mock_hook.get_first.assert_called_with(sql)
+        mock_hook.get_first.assert_called_once_with(sql)
 
     @mock.patch.object(ValueCheckOperator, 'get_db_hook')
     def test_execute_fail(self, mock_get_db_hook):

--- a/tests/operators/test_docker_operator.py
+++ b/tests/operators/test_docker_operator.py
@@ -56,35 +56,35 @@ class TestDockerOperator(unittest.TestCase):
                                   host_tmp_dir='/host/airflow', container_name='test_container')
         operator.execute(None)
 
-        client_class_mock.assert_called_with(base_url='unix://var/run/docker.sock', tls=None,
-                                             version='1.19')
+        client_class_mock.assert_called_once_with(base_url='unix://var/run/docker.sock', tls=None,
+                                                  version='1.19')
 
-        client_mock.create_container.assert_called_with(command='env',
-                                                        name='test_container',
-                                                        environment={
-                                                            'AIRFLOW_TMP_DIR': '/tmp/airflow',
-                                                            'UNIT': 'TEST'
-                                                        },
-                                                        host_config=host_config,
-                                                        image='ubuntu:latest',
-                                                        user=None,
-                                                        working_dir='/container/path'
-                                                        )
-        client_mock.create_host_config.assert_called_with(binds=['/host/path:/container/path',
-                                                                 '/mkdtemp:/tmp/airflow'],
-                                                          network_mode='bridge',
-                                                          shm_size=1000,
-                                                          cpu_shares=1024,
-                                                          mem_limit=None,
-                                                          auto_remove=False,
-                                                          dns=None,
-                                                          dns_search=None)
-        mkdtemp_mock.assert_called_with(dir='/host/airflow', prefix='airflowtmp', suffix='')
-        client_mock.images.assert_called_with(name='ubuntu:latest')
-        client_mock.attach.assert_called_with(container='some_id', stdout=True,
-                                              stderr=True, stream=True)
-        client_mock.pull.assert_called_with('ubuntu:latest', stream=True)
-        client_mock.wait.assert_called_with('some_id')
+        client_mock.create_container.assert_called_once_with(command='env',
+                                                             name='test_container',
+                                                             environment={
+                                                                 'AIRFLOW_TMP_DIR': '/tmp/airflow',
+                                                                 'UNIT': 'TEST'
+                                                             },
+                                                             host_config=host_config,
+                                                             image='ubuntu:latest',
+                                                             user=None,
+                                                             working_dir='/container/path'
+                                                             )
+        client_mock.create_host_config.assert_called_once_with(binds=['/host/path:/container/path',
+                                                                      '/mkdtemp:/tmp/airflow'],
+                                                               network_mode='bridge',
+                                                               shm_size=1000,
+                                                               cpu_shares=1024,
+                                                               mem_limit=None,
+                                                               auto_remove=False,
+                                                               dns=None,
+                                                               dns_search=None)
+        mkdtemp_mock.assert_called_once_with(dir='/host/airflow', prefix='airflowtmp', suffix='')
+        client_mock.images.assert_called_once_with(name='ubuntu:latest')
+        client_mock.attach.assert_called_once_with(container='some_id', stdout=True,
+                                                   stderr=True, stream=True)
+        client_mock.pull.assert_called_once_with('ubuntu:latest', stream=True)
+        client_mock.wait.assert_called_once_with('some_id')
 
     @mock.patch('airflow.operators.docker_operator.tls.TLSConfig')
     @mock.patch('airflow.operators.docker_operator.APIClient')
@@ -106,12 +106,12 @@ class TestDockerOperator(unittest.TestCase):
                                   tls_ca_cert='ca.pem', tls_client_key='key.pem')
         operator.execute(None)
 
-        tls_class_mock.assert_called_with(assert_hostname=None, ca_cert='ca.pem',
-                                          client_cert=('cert.pem', 'key.pem'),
-                                          ssl_version=None, verify=True)
+        tls_class_mock.assert_called_once_with(assert_hostname=None, ca_cert='ca.pem',
+                                               client_cert=('cert.pem', 'key.pem'),
+                                               ssl_version=None, verify=True)
 
-        client_class_mock.assert_called_with(base_url='https://127.0.0.1:2376',
-                                             tls=tls_mock, version=None)
+        client_class_mock.assert_called_once_with(base_url='https://127.0.0.1:2376',
+                                                  tls=tls_mock, version=None)
 
     @mock.patch('airflow.operators.docker_operator.APIClient')
     def test_execute_unicode_logs(self, client_class_mock):
@@ -162,7 +162,7 @@ class TestDockerOperator(unittest.TestCase):
 
         operator.on_kill()
 
-        client_mock.stop.assert_called_with('some_id')
+        client_mock.stop.assert_called_once_with('some_id')
 
     @mock.patch('airflow.operators.docker_operator.APIClient')
     def test_execute_no_docker_conn_id_no_hook(self, operator_client_mock):

--- a/tests/operators/test_docker_swarm_operator.py
+++ b/tests/operators/test_docker_swarm_operator.py
@@ -57,17 +57,17 @@ class TestDockerSwarmOperator(unittest.TestCase):
         )
         operator.execute(None)
 
-        types_mock.TaskTemplate.assert_called_with(
+        types_mock.TaskTemplate.assert_called_once_with(
             container_spec=mock_obj, restart_policy=mock_obj, resources=mock_obj
         )
-        types_mock.ContainerSpec.assert_called_with(
+        types_mock.ContainerSpec.assert_called_once_with(
             image='ubuntu:latest', command='env', user='unittest',
             env={'UNIT': 'TEST', 'AIRFLOW_TMP_DIR': '/tmp/airflow'}
         )
-        types_mock.RestartPolicy.assert_called_with(condition='none')
-        types_mock.Resources.assert_called_with(mem_limit='128m')
+        types_mock.RestartPolicy.assert_called_once_with(condition='none')
+        types_mock.Resources.assert_called_once_with(mem_limit='128m')
 
-        client_class_mock.assert_called_with(
+        client_class_mock.assert_called_once_with(
             base_url='unix://var/run/docker.sock', tls=None, version='1.19'
         )
 
@@ -79,7 +79,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
         self.assertEqual(cskwargs['labels'], {'name': 'airflow__adhoc_airflow__unittest'})
         self.assertTrue(cskwargs['name'].startswith('airflow-'))
         self.assertEqual(client_mock.tasks.call_count, 3)
-        client_mock.remove_service.assert_called_with('some_id')
+        client_mock.remove_service.assert_called_once_with('some_id')
 
     @mock.patch('airflow.operators.docker_operator.APIClient')
     @mock.patch('airflow.contrib.operators.docker_swarm_operator.types')
@@ -140,4 +140,4 @@ class TestDockerSwarmOperator(unittest.TestCase):
 
         operator.on_kill()
 
-        client_mock.remove_service.assert_called_with('some_id')
+        client_mock.remove_service.assert_called_once_with('some_id')

--- a/tests/operators/test_http_operator.py
+++ b/tests/operators/test_http_operator.py
@@ -48,7 +48,11 @@ class TestSimpleHttpOp(unittest.TestCase):
 
         with mock.patch.object(operator.log, 'info') as mock_info:
             operator.execute(None)
-            mock_info.assert_called_with('Example.com fake response')
+            calls = [
+                mock.call('Example.com fake response'),
+                mock.call('Example.com fake response')
+            ]
+            mock_info.has_calls(calls)
 
     @requests_mock.mock()
     def test_response_in_logs_after_failed_check(self, m):
@@ -72,4 +76,8 @@ class TestSimpleHttpOp(unittest.TestCase):
 
         with mock.patch.object(operator.log, 'info') as mock_info:
             self.assertRaises(AirflowException, operator.execute, None)
-            mock_info.assert_called_with('invalid response')
+            calls = [
+                mock.call('Calling HTTP method'),
+                mock.call('invalid response')
+            ]
+            mock_info.assert_has_calls(calls, any_order=True)

--- a/tests/operators/test_slack_operator.py
+++ b/tests/operators/test_slack_operator.py
@@ -92,17 +92,20 @@ class TestSlackAPIPostOperator(unittest.TestCase):
 
         slack_api_post_operator.execute()
 
-        slack_hook_class_mock.assert_called_with(token=test_token, slack_conn_id=None)
+        slack_hook_class_mock.assert_called_once_with(token=test_token, slack_conn_id=None)
 
-        slack_hook_mock.call.assert_called_with(self.expected_method, self.expected_api_params)
+        slack_hook_mock.call.assert_called_once_with(self.expected_method, self.expected_api_params)
+
+        slack_hook_mock.reset_mock()
+        slack_hook_class_mock.reset_mock()
 
         slack_api_post_operator = self.__construct_operator(test_token, None, self.test_api_params)
 
         slack_api_post_operator.execute()
 
-        slack_hook_class_mock.assert_called_with(token=test_token, slack_conn_id=None)
+        slack_hook_class_mock.assert_called_once_with(token=test_token, slack_conn_id=None)
 
-        slack_hook_mock.call.assert_called_with(self.expected_method, self.test_api_params)
+        slack_hook_mock.call.assert_called_once_with(self.expected_method, self.test_api_params)
 
     @mock.patch('airflow.operators.slack_operator.SlackHook')
     def test_execute_with_slack_conn_id_only(self, slack_hook_class_mock):
@@ -114,9 +117,9 @@ class TestSlackAPIPostOperator(unittest.TestCase):
 
         slack_api_post_operator.execute()
 
-        slack_hook_class_mock.assert_called_with(token=None, slack_conn_id=test_slack_conn_id)
+        slack_hook_class_mock.assert_called_once_with(token=None, slack_conn_id=test_slack_conn_id)
 
-        slack_hook_mock.call.assert_called_with(self.expected_method, self.expected_api_params)
+        slack_hook_mock.call.assert_called_once_with(self.expected_method, self.expected_api_params)
 
     def test_init_with_invalid_params(self):
         test_token = 'test_token'

--- a/tests/sensors/test_http_sensor.py
+++ b/tests/sensors/test_http_sensor.py
@@ -155,7 +155,15 @@ class TestHttpSensor(unittest.TestCase):
                 task.execute(None)
 
             self.assertTrue(mock_errors.called)
-            mock_errors.assert_called_with('HTTP error: %s', 'Not Found')
+            calls = [
+                mock.call('HTTP error: %s', 'Not Found'),
+                mock.call('HTTP error: %s', 'Not Found'),
+                mock.call('HTTP error: %s', 'Not Found'),
+                mock.call('HTTP error: %s', 'Not Found'),
+                mock.call('HTTP error: %s', 'Not Found'),
+                mock.call('HTTP error: %s', 'Not Found'),
+            ]
+            mock_errors.assert_has_calls(calls)
 
 
 class FakeSession:

--- a/tests/sensors/test_s3_key_sensor.py
+++ b/tests/sensors/test_s3_key_sensor.py
@@ -72,7 +72,7 @@ class TestS3KeySensor(unittest.TestCase):
         mock_check_for_key = mock_hook.return_value.check_for_key
         mock_check_for_key.return_value = False
         self.assertFalse(s.poke(None))
-        mock_check_for_key.assert_called_with(s.bucket_key, s.bucket_name)
+        mock_check_for_key.assert_called_once_with(s.bucket_key, s.bucket_name)
 
         mock_hook.return_value.check_for_key.return_value = True
         self.assertTrue(s.poke(None))
@@ -87,7 +87,7 @@ class TestS3KeySensor(unittest.TestCase):
         mock_check_for_wildcard_key = mock_hook.return_value.check_for_wildcard_key
         mock_check_for_wildcard_key.return_value = False
         self.assertFalse(s.poke(None))
-        mock_check_for_wildcard_key.assert_called_with(s.bucket_key, s.bucket_name)
+        mock_check_for_wildcard_key.assert_called_once_with(s.bucket_key, s.bucket_name)
 
         mock_check_for_wildcard_key.return_value = True
         self.assertTrue(s.poke(None))

--- a/tests/sensors/test_s3_prefix_sensor.py
+++ b/tests/sensors/test_s3_prefix_sensor.py
@@ -34,7 +34,7 @@ class TestS3PrefixSensor(unittest.TestCase):
 
         mock_hook.return_value.check_for_prefix.return_value = False
         self.assertFalse(s.poke(None))
-        mock_hook.return_value.check_for_prefix.assert_called_with(
+        mock_hook.return_value.check_for_prefix.assert_called_once_with(
             prefix='prefix',
             delimiter='/',
             bucket_name='bucket')

--- a/tests/test_local_settings.py
+++ b/tests/test_local_settings.py
@@ -124,7 +124,7 @@ class TestLocalSettings(unittest.TestCase):
         """
         from airflow import settings
         settings.import_local_settings()
-        log_mock.assert_called_with("Failed to import airflow_local_settings.", exc_info=True)
+        log_mock.assert_called_once_with("Failed to import airflow_local_settings.", exc_info=True)
 
     def test_policy_function(self):
         """

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -171,7 +171,7 @@ class TestLoggingSettings(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     configure_logging()
 
-                mock_info.assert_called_with(
+                mock_info.assert_called_once_with(
                     'Unable to load the config, contains a configuration error.'
                 )
 
@@ -183,7 +183,7 @@ class TestLoggingSettings(unittest.TestCase):
             from airflow.logging_config import configure_logging, log
             with patch.object(log, 'info') as mock_info:
                 configure_logging()
-                mock_info.assert_called_with(
+                mock_info.assert_called_once_with(
                     'Successfully imported user-defined logging config from %s',
                     'etc.airflow.config.{}.LOGGING_CONFIG'.format(
                         SETTINGS_DEFAULT_NAME
@@ -196,7 +196,7 @@ class TestLoggingSettings(unittest.TestCase):
             from airflow.logging_config import configure_logging, log
             with patch.object(log, 'info') as mock_info:
                 configure_logging()
-                mock_info.assert_called_with(
+                mock_info.assert_called_once_with(
                     'Successfully imported user-defined logging config from %s',
                     '{}.LOGGING_CONFIG'.format(
                         SETTINGS_DEFAULT_NAME
@@ -234,7 +234,7 @@ class TestLoggingSettings(unittest.TestCase):
         from airflow.logging_config import configure_logging, log
         with patch.object(log, 'debug') as mock_info:
             configure_logging()
-            mock_info.assert_called_with(
+            mock_info.assert_called_once_with(
                 'Unable to load custom logging, using default config instead'
             )
 

--- a/tests/utils/test_logging_mixin.py
+++ b/tests/utils/test_logging_mixin.py
@@ -67,8 +67,8 @@ class TestLoggingMixin(unittest.TestCase):
         value = "test"
         set_context(log, value)
 
-        handler1.set_context.assert_called_with(value)
-        handler2.set_context.assert_called_with(value)
+        handler1.set_context.assert_called_once_with(value)
+        handler2.set_context.assert_called_once_with(value)
 
     def tearDown(self):
         warnings.resetwarnings()

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -135,14 +135,14 @@ class TestUtils(unittest.TestCase):
         with mock.patch(
                 'io.open', mock.mock_open(read_data="data")) as mock_file:
             utils.open_maybe_zipped('/path/to/some/file.txt')
-            mock_file.assert_called_with('/path/to/some/file.txt', mode='r')
+            mock_file.assert_called_once_with('/path/to/some/file.txt', mode='r')
 
     def test_open_maybe_zipped_normal_file_with_zip_in_name(self):
         path = '/path/to/fakearchive.zip.other/file.txt'
         with mock.patch(
                 'io.open', mock.mock_open(read_data="data")) as mock_file:
             utils.open_maybe_zipped(path)
-            mock_file.assert_called_with(path, mode='r')
+            mock_file.assert_called_once_with(path, mode='r')
 
     @mock.patch("zipfile.is_zipfile")
     @mock.patch("zipfile.ZipFile")


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
