### PR TITLE
[AIRFLOW-YYY] Add fallback for connection project id in GKEPodOperator

### DIFF
--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -25,6 +25,7 @@ import json
 import functools
 import os
 import tempfile
+from contextlib import contextmanager
 from typing import Any, Optional, Dict, Callable, TypeVar, Sequence
 
 import httplib2
@@ -283,32 +284,50 @@ class GoogleCloudBaseHook(BaseHook):
     @staticmethod
     def provide_gcp_credential_file(func: Callable[..., RT]) -> Callable[..., RT]:
         """
-        Function decorator that provides a ``GOOGLE_APPLICATION_CREDENTIALS``
-        environment variable, pointing to file path of a JSON file of service
-        account key.
+        Function decorator that provides a GCP credentials for application supporting Application
+        Default Credentials (ADC) strategy.
+
+        It is recommended to use ``provide_gcp_credential_file_as_context`` context manager to limit the
+        scope when authorization data is available. Using context manager also
+        makes it easier to use multiple connection in one function.
         """
         @functools.wraps(func)
         def wrapper(self: GoogleCloudBaseHook, *args, **kwargs) -> RT:
-            with tempfile.NamedTemporaryFile(mode='w+t') as conf_file:
-                key_path = self._get_field('key_path', None)  # type: Optional[str]  # noqa: E501  #  pylint: disable=protected-access
-                keyfile_dict = self._get_field('keyfile_dict', None)  # type: Optional[Dict]  # noqa: E501  # pylint: disable=protected-access
-                current_env_state = os.environ.get(CREDENTIALS)
-                try:
-                    if key_path:
-                        if key_path.endswith('.p12'):
-                            raise AirflowException(
-                                'Legacy P12 key file are not supported, use a JSON key file.'
-                            )
-                        os.environ[CREDENTIALS] = key_path
-                    elif keyfile_dict:
-                        conf_file.write(keyfile_dict)
-                        conf_file.flush()
-                        os.environ[CREDENTIALS] = conf_file.name
-                    return func(self, *args, **kwargs)
-                finally:
-                    if current_env_state is None:
-                        if CREDENTIALS in os.environ:
-                            del os.environ[CREDENTIALS]
-                    else:
-                        os.environ[CREDENTIALS] = current_env_state
+            with self.provide_gcp_credential_file_as_context():
+                return func(self, *args, **kwargs)
         return wrapper
+
+    @contextmanager
+    def provide_gcp_credential_file_as_context(self):
+        """
+        Context manager that provides a GCP credentials for application supporting ``Application
+        Default Credentials (ADC) strategy <https://cloud.google.com/docs/authentication/production>``__.
+
+        It can be used to provide credentials for external programs (e.g. gcloud) that expect authorization
+        file in ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable.
+        """
+        with tempfile.NamedTemporaryFile(mode='w+t') as conf_file:
+            key_path = self._get_field('key_path', None)  # type: Optional[str]  # noqa: E501  #  pylint: disable=protected-access
+            keyfile_dict = self._get_field('keyfile_dict', None)  # type: Optional[Dict]  # noqa: E501  # pylint: disable=protected-access
+            current_env_state = os.environ.get(CREDENTIALS)
+            try:
+                if key_path:
+                    if key_path.endswith('.p12'):
+                        raise AirflowException(
+                            'Legacy P12 key file are not supported, use a JSON key file.'
+                        )
+                    os.environ[CREDENTIALS] = key_path
+                elif keyfile_dict:
+                    conf_file.write(keyfile_dict)
+                    conf_file.flush()
+                    os.environ[CREDENTIALS] = conf_file.name
+                else:
+                    # We will use the default service account credentials.
+                    pass
+                yield conf_file
+            finally:
+                if current_env_state is None:
+                    if CREDENTIALS in os.environ:
+                        del os.environ[CREDENTIALS]
+                else:
+                    os.environ[CREDENTIALS] = current_env_state

--- a/airflow/contrib/operators/gcs_download_operator.py
+++ b/airflow/contrib/operators/gcs_download_operator.py
@@ -39,12 +39,13 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
     set the ``store_to_xcom_key`` parameter to True push the file content into xcom. When the file size
     exceeds the maximum size for xcom it is recommended to write to a file.
 
-    :param bucket: The Google cloud storage bucket where the object is. (templated)
+    :param bucket: The Google cloud storage bucket where the object is.
+        Must not contain 'gs://' prefix. (templated)
     :type bucket: str
     :param object: The name of the object to download in the Google cloud
         storage bucket. (templated)
     :type object: str
-    :param filename: The file path on the local file system (where the
+    :param filename: The file path, including filename,  on the local file system (where the
         operator is being executed) that the file should be downloaded to. (templated)
         If no filename passed, the downloaded data will not be stored on the local file
         system.

--- a/airflow/gcp/operators/kubernetes_engine.py
+++ b/airflow/gcp/operators/kubernetes_engine.py
@@ -26,10 +26,10 @@ import subprocess
 import tempfile
 from typing import Union, Dict, Optional
 
-from google.auth.environment_vars import CREDENTIALS
 from google.cloud.container_v1.types import Cluster
 
 from airflow import AirflowException
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 from airflow.gcp.hooks.kubernetes_engine import GKEClusterHook
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 from airflow.models import BaseOperator
@@ -238,87 +238,32 @@ class GKEPodOperator(KubernetesPodOperator):
         self.cluster_name = cluster_name
         self.gcp_conn_id = gcp_conn_id
 
+        if self.gcp_conn_id is None:
+            raise AirflowException(
+                "The gcp_conn_id parameter has become required. If you want to use Application Default "
+                "Credentials (ADC) strategy for authorization, create an empty connection "
+                "called `google_cloud_default`.",
+            )
+
     def execute(self, context):
-        # Specifying a service account file allows the user to using non default
-        # authentication for creating a Kubernetes Pod. This is done by setting the
-        # environment variable `GOOGLE_APPLICATION_CREDENTIALS` that gcloud looks at.
-        key_file = None
-
-        # If gcp_conn_id is not specified gcloud will use the default
-        # service account credentials.
-        if self.gcp_conn_id:
-            from airflow.hooks.base_hook import BaseHook
-            # extras is a deserialized json object
-            extras = BaseHook.get_connection(self.gcp_conn_id).extra_dejson
-            # key_file only gets set if a json file is created from a JSON string in
-            # the web ui, else none
-            key_file = self._set_env_from_extras(extras=extras)
-
         # Write config to a temp file and set the environment variable to point to it.
         # This is to avoid race conditions of reading/writing a single file
         with tempfile.NamedTemporaryFile() as conf_file:
             os.environ[KUBE_CONFIG_ENV_VAR] = conf_file.name
-            # Attempt to get/update credentials
-            # We call gcloud directly instead of using google-cloud-python api
-            # because there is no way to write kubernetes config to a file, which is
-            # required by KubernetesPodOperator.
-            # The gcloud command looks at the env variable `KUBECONFIG` for where to save
-            # the kubernetes config file.
-            subprocess.check_call(
-                ["gcloud", "container", "clusters", "get-credentials",
-                 self.cluster_name,
-                 "--zone", self.location,
-                 "--project", self.project_id])
+            hook = GoogleCloudBaseHook(gcp_conn_id=self.gcp_conn_id)
+            with hook.provide_gcp_credential_file_as_context():
+                # Attempt to get/update credentials
+                # We call gcloud directly instead of using google-cloud-python api
+                # because there is no way to write kubernetes config to a file, which is
+                # required by KubernetesPodOperator.
+                # The gcloud command looks at the env variable `KUBECONFIG` for where to save
+                # the kubernetes config file.
+                subprocess.check_call(
+                    ["gcloud", "container", "clusters", "get-credentials",
+                     self.cluster_name,
+                     "--zone", self.location,
+                     "--project", self.project_id])
 
-            # Since the key file is of type mkstemp() closing the file will delete it from
-            # the file system so it cannot be accessed after we don't need it anymore
-            if key_file:
-                key_file.close()
-
-            # Tell `KubernetesPodOperator` where the config file is located
-            self.config_file = os.environ[KUBE_CONFIG_ENV_VAR]
-            return super().execute(context)
-
-    def _set_env_from_extras(self, extras):
-        """
-        Sets the environment variable `GOOGLE_APPLICATION_CREDENTIALS` with either:
-
-        - The path to the keyfile from the specified connection id
-        - A generated file's path if the user specified JSON in the connection id. The
-            file is assumed to be deleted after the process dies due to how mkstemp()
-            works.
-
-        The environment variable is used inside the gcloud command to determine correct
-        service account to use.
-        """
-        key_path = self._get_field(extras, 'key_path', False)
-        keyfile_json_str = self._get_field(extras, 'keyfile_dict', False)
-
-        if not key_path and not keyfile_json_str:
-            self.log.info('Using gcloud with application default credentials.')
-            return None
-        elif key_path:
-            os.environ[CREDENTIALS] = key_path
-            return None
-        else:
-            # Write service account JSON to secure file for gcloud to reference
-            service_key = tempfile.NamedTemporaryFile(delete=False)
-            service_key.write(keyfile_json_str.encode('utf-8'))
-            os.environ[CREDENTIALS] = service_key.name
-            # Return file object to have a pointer to close after use,
-            # thus deleting from file system.
-            return service_key
-
-    def _get_field(self, extras, field, default=None):
-        """
-        Fetches a field from extras, and returns it. This is some Airflow
-        magic. The google_cloud_platform hook type adds custom UI elements
-        to the hook page, which allow admins to specify service_account,
-        key_path, etc. They get formatted as shown below.
-        """
-        long_f = 'extra__google_cloud_platform__{}'.format(field)
-        if long_f in extras:
-            return extras[long_f]
-        else:
-            self.log.info('Field %s not found in extras.', field)
-            return default
+                # Tell `KubernetesPodOperator` where the config file is located
+                self.config_file = os.environ[KUBE_CONFIG_ENV_VAR]
+                return super().execute(context)

--- a/airflow/gcp/operators/kubernetes_engine.py
+++ b/airflow/gcp/operators/kubernetes_engine.py
@@ -209,14 +209,14 @@ class GKEPodOperator(KubernetesPodOperator):
         For more detail about application authentication have a look at the reference:
         https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application
 
-    :param project_id: The Google Developers Console project id
-    :type project_id: str
     :param location: The name of the Google Kubernetes Engine zone in which the
         cluster resides, e.g. 'us-central1-a'
     :type location: str
     :param cluster_name: The name of the Google Kubernetes Engine cluster the pod
         should be spawned in
     :type cluster_name: str
+    :param project_id: The Google Developers Console project id
+    :type project_id: str
     :param gcp_conn_id: The google cloud connection id to use. This allows for
         users to specify a service account.
     :type gcp_conn_id: str
@@ -226,9 +226,9 @@ class GKEPodOperator(KubernetesPodOperator):
 
     @apply_defaults
     def __init__(self,
-                 project_id: str,
                  location: str,
                  cluster_name: str,
+                 project_id: str = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  *args,
                  **kwargs):
@@ -246,11 +246,19 @@ class GKEPodOperator(KubernetesPodOperator):
             )
 
     def execute(self, context):
+        hook = GoogleCloudBaseHook(gcp_conn_id=self.gcp_conn_id)
+        self.project_id = self.project_id or hook.project_id
+
+        if not self.project_id:
+            raise AirflowException("The project id must be passed either as "
+                                   "keyword project_id parameter or as project_id extra "
+                                   "in GCP connection definition. Both are not set!")
+
         # Write config to a temp file and set the environment variable to point to it.
         # This is to avoid race conditions of reading/writing a single file
         with tempfile.NamedTemporaryFile() as conf_file:
             os.environ[KUBE_CONFIG_ENV_VAR] = conf_file.name
-            hook = GoogleCloudBaseHook(gcp_conn_id=self.gcp_conn_id)
+
             with hook.provide_gcp_credential_file_as_context():
                 # Attempt to get/update credentials
                 # We call gcloud directly instead of using google-cloud-python api

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -18,11 +18,9 @@
 Integration
 ===========
 
-- :ref:`Azure`
-- :ref:`AWS`
-- :ref:`Databricks`
-- :ref:`GCP`
-- :ref:`Qubole`
+.. contents:: Content
+  :local:
+  :depth: 1
 
 .. _Azure:
 

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -144,6 +144,13 @@ AWS: Amazon Web Services
 Airflow has extensive support for Amazon Web Services. But note that the Hooks, Sensors and
 Operators are in the contrib section.
 
+Logging
+'''''''
+
+Airflow can be configured to read and write task logs in Amazon Simple Storage Service (Amazon S3).
+See :ref:`write-logs-amazon`.
+
+
 AWS EMR
 '''''''
 

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -33,6 +33,13 @@ Airflow has limited support for Microsoft Azure: interfaces exist only for Azure
 Storage and Azure Data Lake. Hook, Sensor and Operator for Blob Storage and
 Azure Data Lake Hook are in contrib section.
 
+Logging
+'''''''
+
+Airflow can be configured to read and write task logs in Azure Blob Storage.
+See :ref:`write-logs-azure`.
+
+
 Azure Blob Storage
 ''''''''''''''''''
 
@@ -67,12 +74,6 @@ and password (=Storage account key), or login and SAS token in the extra field
 
 :class:`airflow.contrib.hooks.azure_fileshare_hook.AzureFileShareHook`:
     Interface with Azure File Share.
-
-Logging
-'''''''
-
-Airflow can be configured to read and write task logs in Azure Blob Storage.
-See :ref:`write-logs-azure`.
 
 Azure CosmosDB
 ''''''''''''''

--- a/setup.py
+++ b/setup.py
@@ -346,6 +346,7 @@ def do_setup():
             'jinja2>=2.10.1, <2.11.0',
             'lazy_object_proxy~=1.3',
             'markdown>=2.5.2, <3.0',
+            'marshmallow-sqlalchemy>=0.16.1, <0.19.0',
             'pandas>=0.17.1, <1.0.0',
             'pendulum==1.4.4',
             'psutil>=4.2.0, <6.0.0',

--- a/tests/gcp/operators/test_kubernetes_engine.py
+++ b/tests/gcp/operators/test_kubernetes_engine.py
@@ -16,7 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import json
 import os
 import unittest
 
@@ -27,7 +27,8 @@ from airflow import AirflowException
 from airflow.gcp.operators.kubernetes_engine import GKEClusterCreateOperator, \
     GKEClusterDeleteOperator, GKEPodOperator
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
-from tests.compat import mock
+from airflow.models import Connection
+from tests.compat import mock, PropertyMock
 
 TEST_GCP_PROJECT_ID = 'test-id'
 PROJECT_LOCATION = 'test-location'
@@ -152,13 +153,27 @@ class TestGKEPodOperator(unittest.TestCase):
 
     # pylint:disable=unused-argument
     @mock.patch(
+        "airflow.hooks.base_hook.BaseHook.get_connections",
+        return_value=[Connection(
+            extra=json.dumps({})
+        )]
+    )
+    @mock.patch(
         'airflow.contrib.operators.kubernetes_pod_operator.KubernetesPodOperator.execute')
     @mock.patch('tempfile.NamedTemporaryFile')
     @mock.patch("subprocess.check_call")
-    def test_execute_conn_id_none(self, proc_mock, file_mock, exec_mock):
-        self.gke_op.gcp_conn_id = None
+    @mock.patch.dict(os.environ, {CREDENTIALS: '/tmp/local-creds'})
+    def test_execute_conn_id_none(self, proc_mock, file_mock, exec_mock, get_conn):
+        type(file_mock.return_value.__enter__.return_value).name = PropertyMock(side_effect=[
+            FILE_NAME
+        ])
 
-        file_mock.return_value.__enter__.return_value.name = FILE_NAME
+        def assert_credentials(*args, **kwargs):
+            # since we passed in keyfile_path we should get a file
+            self.assertIn(CREDENTIALS, os.environ)
+            self.assertEqual(os.environ[CREDENTIALS], '/tmp/local-creds')
+
+        proc_mock.side_effect = assert_credentials
 
         self.gke_op.execute(None)
 
@@ -173,29 +188,35 @@ class TestGKEPodOperator(unittest.TestCase):
         self.assertEqual(self.gke_op.config_file, FILE_NAME)
 
     # pylint:disable=unused-argument
-    @mock.patch('airflow.hooks.base_hook.BaseHook.get_connection')
+    @mock.patch(
+        "airflow.hooks.base_hook.BaseHook.get_connections",
+        return_value=[Connection(
+            extra=json.dumps({
+                'extra__google_cloud_platform__key_path': '/path/to/file'
+            })
+        )]
+    )
     @mock.patch(
         'airflow.contrib.operators.kubernetes_pod_operator.KubernetesPodOperator.execute')
     @mock.patch('tempfile.NamedTemporaryFile')
     @mock.patch("subprocess.check_call")
     @mock.patch.dict(os.environ, {})
     def test_execute_conn_id_path(self, proc_mock, file_mock, exec_mock, get_con_mock):
-        # gcp_conn_id is defaulted to `google_cloud_default`
+        type(file_mock.return_value.__enter__.return_value).name = PropertyMock(side_effect=[
+            FILE_NAME
+        ])
 
-        file_path = '/path/to/file'
-        kaeyfile_dict = {"extra__google_cloud_platform__key_path": file_path}
-        get_con_mock.return_value.extra_dejson = kaeyfile_dict
-        file_mock.return_value.__enter__.return_value.name = FILE_NAME
+        def assert_credentials(*args, **kwargs):
+            # since we passed in keyfile_path we should get a file
+            self.assertIn(CREDENTIALS, os.environ)
+            self.assertEqual(os.environ[CREDENTIALS], '/path/to/file')
 
+        proc_mock.side_effect = assert_credentials
         self.gke_op.execute(None)
 
         # Assert Environment Variable is being set correctly
         self.assertIn(KUBE_ENV_VAR, os.environ)
         self.assertEqual(os.environ[KUBE_ENV_VAR], FILE_NAME)
-
-        self.assertIn(CREDENTIALS, os.environ)
-        # since we passed in keyfile_path we should get a file
-        self.assertEqual(os.environ[CREDENTIALS], file_path)
 
         # Assert the gcloud command being called correctly
         proc_mock.assert_called_once_with(
@@ -205,23 +226,29 @@ class TestGKEPodOperator(unittest.TestCase):
 
     # pylint:disable=unused-argument
     @mock.patch.dict(os.environ, {})
-    @mock.patch('airflow.hooks.base_hook.BaseHook.get_connection')
+    @mock.patch(
+        "airflow.hooks.base_hook.BaseHook.get_connections",
+        return_value=[Connection(
+            extra=json.dumps({
+                "extra__google_cloud_platform__keyfile_dict": '{"private_key": "r4nd0m_k3y"}'
+            })
+        )]
+    )
     @mock.patch(
         'airflow.contrib.operators.kubernetes_pod_operator.KubernetesPodOperator.execute')
     @mock.patch('tempfile.NamedTemporaryFile')
     @mock.patch("subprocess.check_call")
     def test_execute_conn_id_dict(self, proc_mock, file_mock, exec_mock, get_con_mock):
-        # gcp_conn_id is defaulted to `google_cloud_default`
-        file_path = '/path/to/file'
+        type(file_mock.return_value.__enter__.return_value).name = PropertyMock(side_effect=[
+            FILE_NAME, '/path/to/new-file'
+        ])
 
-        # This is used in the _set_env_from_extras method
-        file_mock.return_value.name = file_path
-        # This is used in the execute method
-        file_mock.return_value.__enter__.return_value.name = FILE_NAME
+        def assert_credentials(*args, **kwargs):
+            # since we passed in keyfile_dict we should get a new file
+            self.assertIn(CREDENTIALS, os.environ)
+            self.assertEqual(os.environ[CREDENTIALS], '/path/to/new-file')
 
-        keyfile_dict = {"extra__google_cloud_platform__keyfile_dict":
-                        '{"private_key": "r4nd0m_k3y"}'}
-        get_con_mock.return_value.extra_dejson = keyfile_dict
+        proc_mock.side_effect = assert_credentials
 
         self.gke_op.execute(None)
 
@@ -229,74 +256,8 @@ class TestGKEPodOperator(unittest.TestCase):
         self.assertIn(KUBE_ENV_VAR, os.environ)
         self.assertEqual(os.environ[KUBE_ENV_VAR], FILE_NAME)
 
-        self.assertIn(CREDENTIALS, os.environ)
-        # since we passed in keyfile_path we should get a file
-        self.assertEqual(os.environ[CREDENTIALS], file_path)
-
         # Assert the gcloud command being called correctly
         proc_mock.assert_called_once_with(
             GCLOUD_COMMAND.format(CLUSTER_NAME, PROJECT_LOCATION, TEST_GCP_PROJECT_ID).split())
 
         self.assertEqual(self.gke_op.config_file, FILE_NAME)
-
-    @mock.patch.dict(os.environ, {})
-    def test_set_env_from_extras_none(self):
-        extras = {}
-        self.gke_op._set_env_from_extras(extras)
-        # _set_env_from_extras should not edit os.environ if extras does not specify
-        self.assertNotIn(CREDENTIALS, os.environ)
-
-    @mock.patch.dict(os.environ, {})
-    @mock.patch('tempfile.NamedTemporaryFile')
-    def test_set_env_from_extras_dict(self, file_mock):
-        keyfile_dict_str = '{ \"test\": \"cluster\" }'
-        extras = {
-            'extra__google_cloud_platform__keyfile_dict': keyfile_dict_str,
-        }
-
-        def mock_temp_write(content):
-            if not isinstance(content, bytes):
-                raise TypeError("a bytes-like object is required, not {}".format(type(content).__name__))
-
-        file_mock.return_value.write = mock_temp_write
-        file_mock.return_value.name = FILE_NAME
-
-        key_file = self.gke_op._set_env_from_extras(extras)
-        self.assertEqual(os.environ[CREDENTIALS], FILE_NAME)
-        self.assertIsInstance(key_file, mock.MagicMock)
-
-    @mock.patch.dict(os.environ, {})
-    def test_set_env_from_extras_path(self):
-        test_path = '/test/path'
-
-        extras = {
-            'extra__google_cloud_platform__key_path': test_path,
-        }
-
-        self.gke_op._set_env_from_extras(extras)
-        self.assertEqual(os.environ[CREDENTIALS], test_path)
-
-    def test_get_field(self):
-        field_name = 'test_field'
-        field_value = 'test_field_value'
-        extras = {
-            'extra__google_cloud_platform__{}'.format(field_name):
-                field_value
-        }
-
-        ret_val = self.gke_op._get_field(extras, field_name)
-        self.assertEqual(field_value, ret_val)
-
-    @mock.patch('airflow.gcp.operators.kubernetes_engine.GKEPodOperator.log')
-    def test_get_field_fail(self, log_mock):
-        log_mock.info = mock.Mock()
-        log_str = 'Field %s not found in extras.'
-        field_name = 'test_field'
-        field_value = 'test_field_value'
-
-        extras = {}
-
-        ret_val = self.gke_op._get_field(extras, field_name, default=field_value)
-        # Assert default is returned upon failure
-        self.assertEqual(field_value, ret_val)
-        log_mock.info.assert_called_once_with(log_str, field_name)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
