### PR TITLE
Fix tests

### DIFF
--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -84,31 +84,56 @@ class TestBigQueryDataframeResults(unittest.TestCase):
     def setUp(self):
         self.instance = hook.BigQueryHook()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @unittest.skipIf(not bq_available, 'BQ is not available to run tests')
-    def test_output_is_dataframe_with_valid_query(self):
+    def test_output_is_dataframe_with_valid_query(self, mock_project_id):
         import pandas as pd
         df = self.instance.get_pandas_df('select 1')
         self.assertIsInstance(df, pd.DataFrame)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @unittest.skipIf(not bq_available, 'BQ is not available to run tests')
-    def test_throws_exception_with_invalid_query(self):
+    def test_throws_exception_with_invalid_query(self, mock_project_id):
         with self.assertRaises(Exception) as context:
             self.instance.get_pandas_df('from `1`')
         self.assertIn('Reason: ', str(context.exception), "")
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @unittest.skipIf(not bq_available, 'BQ is not available to run tests')
-    def test_succeeds_with_explicit_legacy_query(self):
+    def test_succeeds_with_explicit_legacy_query(self, mock_project_id):
         df = self.instance.get_pandas_df('select 1', dialect='legacy')
         self.assertEqual(df.iloc(0)[0][0], 1)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @unittest.skipIf(not bq_available, 'BQ is not available to run tests')
-    def test_succeeds_with_explicit_std_query(self):
+    def test_succeeds_with_explicit_std_query(self, mock_project_id):
         df = self.instance.get_pandas_df(
             'select * except(b) from (select 1 a, 2 b)', dialect='standard')
         self.assertEqual(df.iloc(0)[0][0], 1)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @unittest.skipIf(not bq_available, 'BQ is not available to run tests')
-    def test_throws_exception_with_incompatible_syntax(self):
+    def test_throws_exception_with_incompatible_syntax(self, mock_project_id):
         with self.assertRaises(Exception) as context:
             self.instance.get_pandas_df(
                 'select * except(b) from (select 1 a, 2 b)', dialect='legacy')

--- a/tests/gcp/hooks/test_bigtable.py
+++ b/tests/gcp/hooks/test_bigtable.py
@@ -186,8 +186,13 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
                         new=mock_base_gcp_hook_default_project_id):
             self.bigtable_hook_default_project_id = BigtableHook(gcp_conn_id='test')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.bigtable.BigtableHook._get_client')
-    def test_get_instance(self, get_client):
+    def test_get_instance(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True
@@ -211,8 +216,13 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
         get_client.assert_called_once_with(project_id='new-project')
         self.assertIsNotNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.bigtable.BigtableHook._get_client')
-    def test_get_instance_no_instance(self, get_client):
+    def test_get_instance_no_instance(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = False
@@ -223,8 +233,13 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
         get_client.assert_called_once_with(project_id='example-project')
         self.assertIsNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.bigtable.BigtableHook._get_client')
-    def test_delete_instance(self, get_client):
+    def test_delete_instance(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True
@@ -251,8 +266,13 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
         get_client.assert_called_once_with(project_id='new-project')
         self.assertIsNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.bigtable.BigtableHook._get_client')
-    def test_delete_instance_no_instance(self, get_client):
+    def test_delete_instance_no_instance(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = False
@@ -264,9 +284,14 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
         delete_method.assert_not_called()
         get_client.assert_called_once_with(project_id='example-project')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('google.cloud.bigtable.instance.Instance.create')
     @mock.patch('airflow.gcp.hooks.bigtable.BigtableHook._get_client')
-    def test_create_instance(self, get_client, instance_create):
+    def test_create_instance(self, get_client, instance_create, mock_project_id):
         operation = mock.Mock()
         operation.result_return_value = Instance(instance_id=CBT_INSTANCE, client=get_client)
         instance_create.return_value = operation
@@ -293,8 +318,13 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
         instance_create.assert_called_once_with(clusters=mock.ANY)
         self.assertEqual(res.instance_id, 'instance')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.bigtable.BigtableHook._get_client')
-    def test_delete_table(self, get_client):
+    def test_delete_table(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         table_delete_method = instance_method.return_value.table.return_value.delete

--- a/tests/gcp/hooks/test_cloud_build.py
+++ b/tests/gcp/hooks/test_cloud_build.py
@@ -29,7 +29,7 @@ from tests.compat import PropertyMock
 from tests.contrib.utils.base_gcp_mock import (
     mock_base_gcp_hook_default_project_id,
     mock_base_gcp_hook_no_default_project_id,
-)
+    GCP_PROJECT_ID_HOOK_UNIT_TEST)
 
 
 TEST_CREATE_BODY = {
@@ -105,9 +105,14 @@ class TestCloudBuildHookWithPassedProjectId(unittest.TestCase):
 
         self.assertEqual(result, TEST_BUILD)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch("airflow.gcp.hooks.cloud_build.CloudBuildHook.get_conn")
     @mock.patch("airflow.gcp.hooks.cloud_build.time.sleep")
-    def test_error_operation(self, _, get_conn_mock):
+    def test_error_operation(self, _, get_conn_mock, mock_project_id):
         service_mock = get_conn_mock.return_value
 
         service_mock.projects.return_value.builds.return_value.create.return_value.execute.return_value = (
@@ -130,8 +135,13 @@ class TestGcpComputeHookWithDefaultProjectIdFromConnection(unittest.TestCase):
         ):
             self.hook = CloudBuildHook(gcp_conn_id="test")
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch("airflow.gcp.hooks.cloud_build.CloudBuildHook.get_conn")
-    def test_build_immediately_complete(self, get_conn_mock):
+    def test_build_immediately_complete(self, get_conn_mock, mock_project_id):
         service_mock = get_conn_mock.return_value
 
         service_mock.projects.return_value.builds.return_value.create.return_value.execute.return_value = (
@@ -152,9 +162,14 @@ class TestGcpComputeHookWithDefaultProjectIdFromConnection(unittest.TestCase):
 
         self.assertEqual(result, TEST_BUILD)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch("airflow.gcp.hooks.cloud_build.CloudBuildHook.get_conn")
     @mock.patch("airflow.gcp.hooks.cloud_build.time.sleep")
-    def test_waiting_operation(self, _, get_conn_mock):
+    def test_waiting_operation(self, _, get_conn_mock, mock_project_id):
         service_mock = get_conn_mock.return_value
 
         service_mock.projects.return_value.builds.return_value.create.return_value.execute.return_value = (
@@ -174,9 +189,14 @@ class TestGcpComputeHookWithDefaultProjectIdFromConnection(unittest.TestCase):
 
         self.assertEqual(result, TEST_BUILD)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch("airflow.gcp.hooks.cloud_build.CloudBuildHook.get_conn")
     @mock.patch("airflow.gcp.hooks.cloud_build.time.sleep")
-    def test_error_operation(self, _, get_conn_mock):
+    def test_error_operation(self, _, get_conn_mock, mock_project_id):
         service_mock = get_conn_mock.return_value
 
         service_mock.projects.return_value.builds.return_value.create.return_value.execute.return_value = (

--- a/tests/gcp/hooks/test_cloud_storage_transfer_service.py
+++ b/tests/gcp/hooks/test_cloud_storage_transfer_service.py
@@ -43,7 +43,7 @@ from airflow.gcp.hooks.cloud_storage_transfer_service import (
 from tests.contrib.utils.base_gcp_mock import (
     mock_base_gcp_hook_no_default_project_id,
     mock_base_gcp_hook_default_project_id,
-)
+    GCP_PROJECT_ID_HOOK_UNIT_TEST)
 from tests.compat import mock, PropertyMock
 
 NAME = "name"
@@ -381,8 +381,13 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         ):
             self.gct_hook = GCPTransferServiceHook(gcp_conn_id='test')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
-    def test_create_transfer_job(self, get_conn):
+    def test_create_transfer_job(self, get_conn, mock_project_id):
         create_method = get_conn.return_value.transferJobs.return_value.create
         execute_method = create_method.return_value.execute
         execute_method.return_value = deepcopy(TEST_TRANSFER_JOB)
@@ -391,8 +396,13 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         create_method.assert_called_once_with(body=self._with_project_id(TEST_BODY, 'example-project'))
         execute_method.assert_called_once_with(num_retries=5)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
-    def test_get_transfer_job(self, get_conn):
+    def test_get_transfer_job(self, get_conn, mock_project_id):
         get_method = get_conn.return_value.transferJobs.return_value.get
         execute_method = get_method.return_value.execute
         execute_method.return_value = TEST_TRANSFER_JOB
@@ -402,8 +412,13 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         get_method.assert_called_once_with(jobName=TEST_TRANSFER_JOB_NAME, projectId='example-project')
         execute_method.assert_called_once_with(num_retries=5)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
-    def test_list_transfer_job(self, get_conn):
+    def test_list_transfer_job(self, get_conn, mock_project_id):
         list_method = get_conn.return_value.transferJobs.return_value.list
         list_execute_method = list_method.return_value.execute
         list_execute_method.return_value = {TRANSFER_JOBS: [TEST_TRANSFER_JOB]}
@@ -425,8 +440,13 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         )
         list_execute_method.assert_called_once_with(num_retries=5)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
-    def test_update_transfer_job(self, get_conn):
+    def test_update_transfer_job(self, get_conn, mock_project_id):
         update_method = get_conn.return_value.transferJobs.return_value.patch
         execute_method = update_method.return_value.execute
         execute_method.return_value = TEST_TRANSFER_JOB
@@ -476,8 +496,13 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         get_method.assert_called_once_with(name=TEST_TRANSFER_OPERATION_NAME)
         execute_method.assert_called_once_with(num_retries=5)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
-    def test_list_transfer_operation(self, get_conn):
+    def test_list_transfer_operation(self, get_conn, mock_project_id):
         list_method = get_conn.return_value.transferOperations.return_value.list
         list_execute_method = list_method.return_value.execute
         list_execute_method.return_value = {OPERATIONS: [TEST_TRANSFER_OPERATION]}

--- a/tests/gcp/hooks/test_functions.py
+++ b/tests/gcp/hooks/test_functions.py
@@ -143,9 +143,14 @@ class TestFunctionHookDefaultProjectId(unittest.TestCase):
                         new=mock_base_gcp_hook_default_project_id):
             self.gcf_function_hook = GcfHook(gcp_conn_id='test', api_version='v1')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.functions.GcfHook.get_conn')
     @mock.patch('airflow.gcp.hooks.functions.GcfHook._wait_for_operation_to_complete')
-    def test_create_new_function(self, wait_for_operation_to_complete, get_conn):
+    def test_create_new_function(self, wait_for_operation_to_complete, get_conn, mock_project_id):
         create_method = get_conn.return_value.projects.return_value.locations.\
             return_value.functions.return_value.create
         execute_method = create_method.return_value.execute
@@ -231,9 +236,14 @@ class TestFunctionHookDefaultProjectId(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
         wait_for_operation_to_complete.assert_called_once_with(operation_name='operation_id')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('requests.put')
     @mock.patch('airflow.gcp.hooks.functions.GcfHook.get_conn')
-    def test_upload_function_zip(self, get_conn, requests_put):
+    def test_upload_function_zip(self, get_conn, requests_put, mock_project_id):
         mck, open_module = get_open_mock()
         with mock.patch('{}.open'.format(open_module), mck):
             generate_upload_url_method = get_conn.return_value.projects.return_value.locations. \

--- a/tests/gcp/hooks/test_gcp_compute_hook.py
+++ b/tests/gcp/hooks/test_gcp_compute_hook.py
@@ -354,9 +354,14 @@ class TestGcpComputeHookDefaultProjectId(unittest.TestCase):
                         new=mock_base_gcp_hook_default_project_id):
             self.gce_hook = GceHook(gcp_conn_id='test')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.compute.GceHook.get_conn')
     @mock.patch('airflow.gcp.hooks.compute.GceHook._wait_for_operation_to_complete')
-    def test_start_instance(self, wait_for_operation_to_complete, get_conn):
+    def test_start_instance(self, wait_for_operation_to_complete, get_conn, mock_project_id):
         start_method = get_conn.return_value.instances.return_value.start
         execute_method = start_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -389,9 +394,14 @@ class TestGcpComputeHookDefaultProjectId(unittest.TestCase):
                                                                operation_name='operation_id',
                                                                zone='zone')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.compute.GceHook.get_conn')
     @mock.patch('airflow.gcp.hooks.compute.GceHook._wait_for_operation_to_complete')
-    def test_stop_instance(self, wait_for_operation_to_complete, get_conn):
+    def test_stop_instance(self, wait_for_operation_to_complete, get_conn, mock_project_id):
         stop_method = get_conn.return_value.instances.return_value.stop
         execute_method = stop_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -424,9 +434,14 @@ class TestGcpComputeHookDefaultProjectId(unittest.TestCase):
                                                                operation_name='operation_id',
                                                                zone='zone')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.compute.GceHook.get_conn')
     @mock.patch('airflow.gcp.hooks.compute.GceHook._wait_for_operation_to_complete')
-    def test_set_machine_type_instance(self, wait_for_operation_to_complete, get_conn):
+    def test_set_machine_type_instance(self, wait_for_operation_to_complete, get_conn, mock_project_id):
         execute_method = get_conn.return_value.instances.return_value.setMachineType.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
         wait_for_operation_to_complete.return_value = None
@@ -457,9 +472,14 @@ class TestGcpComputeHookDefaultProjectId(unittest.TestCase):
                                                                operation_name='operation_id',
                                                                zone='zone')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.compute.GceHook.get_conn')
     @mock.patch('airflow.gcp.hooks.compute.GceHook._wait_for_operation_to_complete')
-    def test_get_instance_template(self, wait_for_operation_to_complete, get_conn):
+    def test_get_instance_template(self, wait_for_operation_to_complete, get_conn, mock_project_id):
         get_method = get_conn.return_value.instanceTemplates.return_value.get
         execute_method = get_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -486,9 +506,14 @@ class TestGcpComputeHookDefaultProjectId(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
         wait_for_operation_to_complete.assert_not_called()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.compute.GceHook.get_conn')
     @mock.patch('airflow.gcp.hooks.compute.GceHook._wait_for_operation_to_complete')
-    def test_insert_instance_template(self, wait_for_operation_to_complete, get_conn):
+    def test_insert_instance_template(self, wait_for_operation_to_complete, get_conn, mock_project_id):
         insert_method = get_conn.return_value.instanceTemplates.return_value.insert
         execute_method = insert_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -521,9 +546,14 @@ class TestGcpComputeHookDefaultProjectId(unittest.TestCase):
         wait_for_operation_to_complete.assert_called_once_with(project_id='new-project',
                                                                operation_name='operation_id')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.compute.GceHook.get_conn')
     @mock.patch('airflow.gcp.hooks.compute.GceHook._wait_for_operation_to_complete')
-    def test_get_instance_group_manager(self, wait_for_operation_to_complete, get_conn):
+    def test_get_instance_group_manager(self, wait_for_operation_to_complete, get_conn, mock_project_id):
         get_method = get_conn.return_value.instanceGroupManagers.return_value.get
         execute_method = get_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -558,9 +588,14 @@ class TestGcpComputeHookDefaultProjectId(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
         wait_for_operation_to_complete.assert_not_called()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.compute.GceHook.get_conn')
     @mock.patch('airflow.gcp.hooks.compute.GceHook._wait_for_operation_to_complete')
-    def test_patch_instance_group_manager(self, wait_for_operation_to_complete, get_conn):
+    def test_patch_instance_group_manager(self, wait_for_operation_to_complete, get_conn, mock_project_id):
         patch_method = get_conn.return_value.instanceGroupManagers.return_value.patch
         execute_method = patch_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}

--- a/tests/gcp/hooks/test_spanner.py
+++ b/tests/gcp/hooks/test_spanner.py
@@ -59,8 +59,13 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         instance_method.assert_called_once_with(instance_id='instance')
         self.assertIsNotNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
-    def test_create_instance(self, get_client):
+    def test_create_instance(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         create_method = instance_method.return_value.create
         create_method.return_value = False
@@ -96,8 +101,13 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
             node_count=1)
         self.assertIsNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
-    def test_update_instance(self, get_client):
+    def test_update_instance(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True
@@ -135,8 +145,13 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         update_method.assert_called_once_with()
         self.assertIsNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
-    def test_delete_instance(self, get_client):
+    def test_delete_instance(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True
@@ -166,8 +181,13 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         delete_method.assert_called_once_with()
         self.assertIsNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
-    def test_get_database(self, get_client):
+    def test_get_database(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True
@@ -201,8 +221,13 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         database_exists_method.assert_called_once_with()
         self.assertIsNotNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
-    def test_create_database(self, get_client):
+    def test_create_database(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True
@@ -236,8 +261,13 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         database_create_method.assert_called_once_with()
         self.assertIsNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
-    def test_update_database(self, get_client):
+    def test_update_database(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True
@@ -271,8 +301,13 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         database_update_ddl_method.assert_called_once_with(ddl_statements=[], operation_id=None)
         self.assertIsNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
-    def test_delete_database(self, get_client):
+    def test_delete_database(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True
@@ -310,8 +345,13 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         database_drop_method.assert_called_once_with()
         self.assertTrue(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
+    )
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
-    def test_execute_dml(self, get_client):
+    def test_execute_dml(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
