### PR TITLE
[AIRFLOW-YYY] Add GKE example with XCOM

### DIFF
--- a/airflow/gcp/example_dags/example_kubernetes_engine.py
+++ b/airflow/gcp/example_dags/example_kubernetes_engine.py
@@ -28,6 +28,7 @@ from airflow.gcp.operators.kubernetes_engine import (
     GKEClusterDeleteOperator,
     GKEPodOperator,
 )
+from airflow.operators.bash_operator import BashOperator
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "example-project")
 GCP_LOCATION = os.environ.get("GCP_GKE_LOCATION", "europe-north1-a")
@@ -59,6 +60,23 @@ with models.DAG(
         name="test-pod",
     )
 
+    pod_task_xcom = GKEPodOperator(
+        task_id="pod_task_xcom",
+        project_id=GCP_PROJECT_ID,
+        location=GCP_LOCATION,
+        cluster_name=CLUSTER_NAME,
+        do_xcom_push=True,
+        namespace="default",
+        image="alpine",
+        cmds=["sh", "-c", 'mkdir -p /airflow/xcom/;echo \'[1,2,3,4]\' > /airflow/xcom/return.json'],
+        name="test-pod-xcom",
+    )
+
+    pod_task_xcom_result = BashOperator(
+        bash_command="echo \"{{ task_instance.xcom_pull('pod_task_xcom')[0] }}\"",
+        task_id="pod_task_xcom_result",
+    )
+
     delete_cluster = GKEClusterDeleteOperator(
         task_id="delete_cluster",
         name=CLUSTER_NAME,
@@ -67,3 +85,5 @@ with models.DAG(
     )
 
     create_cluster >> pod_task >> delete_cluster
+    create_cluster >> pod_task_xcom >> delete_cluster
+    pod_task_xcom >> pod_task_xcom_result


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
