### PR TITLE
Add/singularity operator rebase

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -582,7 +582,7 @@ getsection = conf.getsection
 has_option = conf.has_option
 remove_option = conf.remove_option
 as_dict = conf.as_dict
-set = conf.set # noqa
+set = conf.set  # noqa
 
 for func in [load_test_config, get, getboolean, getfloat, getint, has_option,
              remove_option, as_dict, set]:

--- a/airflow/contrib/example_dags/example_singularity_operator.py
+++ b/airflow/contrib/example_dags/example_singularity_operator.py
@@ -17,10 +17,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from airflow import DAG
-from airflow.operators.bash_operator import BashOperator
 from datetime import datetime, timedelta
+
+from airflow import DAG
 from airflow.contrib.operators.singularity_operator import SingularityOperator
+from airflow.operators.bash_operator import BashOperator
 
 default_args = {
     'owner': 'airflow',

--- a/airflow/contrib/example_dags/example_singularity_operator.py
+++ b/airflow/contrib/example_dags/example_singularity_operator.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow import DAG
+from airflow.operators.bash_operator import BashOperator
+from datetime import datetime, timedelta
+from airflow.contrib.operators.singularity_operator import SingularityOperator
+
+default_args = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'start_date': datetime.utcnow(),
+    'email': ['airflow@example.com'],
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 1,
+    'retry_delay': timedelta(minutes=5)
+}
+
+dag = DAG(
+    'singularity_sample', default_args=default_args, schedule_interval=timedelta(minutes=10))
+
+t1 = BashOperator(
+    task_id='print_date',
+    bash_command='date',
+    dag=dag)
+
+t2 = BashOperator(
+    task_id='sleep',
+    bash_command='sleep 5',
+    retries=3,
+    dag=dag)
+
+t3 = SingularityOperator(command='/bin/sleep 30',
+                         image='docker://busybox:1.30.1',
+                         task_id='singularity_op_tester',
+                         dag=dag)
+
+t4 = BashOperator(
+    task_id='print_hello',
+    bash_command='echo "hello world!!!"',
+    dag=dag)
+
+t1.set_downstream(t2)
+t1.set_downstream(t3)
+t3.set_downstream(t4)

--- a/airflow/contrib/operators/singularity_operator.py
+++ b/airflow/contrib/operators/singularity_operator.py
@@ -16,14 +16,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import ast
+import os
+import shutil
+
+from spython.main import Client
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
-from spython.main import Client
-import shutil
-import ast
-import os
 
 
 class SingularityOperator(BaseOperator):

--- a/airflow/contrib/operators/singularity_operator.py
+++ b/airflow/contrib/operators/singularity_operator.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+from spython.main import Client
+import shutil
+import ast
+import os
+
+
+class SingularityOperator(BaseOperator):
+    """
+    Execute a command inside a Singularity container
+
+    Singularity has more seamless connection to the host than Docker, so
+    no special binds are needed to ensure binding content in the user $HOME
+    and temporary directories. If the user needs custom binds, this can
+    be done with --volumes
+
+    :param image: Singularity image or URI from which to create the container.
+    :type image: str
+    :param auto_remove: Delete the container when the process exits
+                        The default is False.
+    :type auto_remove: bool
+    :param command: Command to be run in the container. (templated)
+    :type command: str or list
+    :param start_command: start command to pass to the container instance
+    :type start_command: string or list
+    :param environment: Environment variables to set in the container. (templated)
+    :type environment: dict
+    :param force_pull: Pull the image on every run. Default is False.
+    :type force_pull: bool
+    :param volumes: List of volumes to mount into the container, e.g.
+        ``['/host/path:/container/path', '/host/path2:/container/path2']``.
+    :param options: other flags (list) to provide to the instance start
+    :type options: list
+    :param working_dir: Working directory to
+        set on the container (equivalent to the -w switch the docker client)
+    :type working_dir: str
+    """
+    template_fields = ('command', 'environment',)
+    template_ext = ('.sh', '.bash',)
+
+    @apply_defaults
+    def __init__(
+            self,
+            image,
+            api_version=None,
+            command=None,
+            start_command=None,
+            environment=None,
+            pull_folder=None,
+            force_pull=False,
+            volumes=None,
+            options=None,
+            working_dir=None,
+            auto_remove=False,
+            *args,
+            **kwargs):
+
+        super(SingularityOperator, self).__init__(*args, **kwargs)
+        self.api_version = api_version
+        self.auto_remove = auto_remove
+        self.command = command
+        self.start_command = start_command
+        self.environment = environment or {}
+        self.force_pull = force_pull
+        self.image = image
+        self.instance = None
+        self.options = options or []
+        self.pull_folder = pull_folder
+        self.volumes = volumes or []
+        self.working_dir = working_dir
+        self.cli = None
+        self.container = None
+
+    def execute(self, context):
+        self.log.info('Preparing Singularity container %s', self.image)
+        self.cli = Client
+
+        if not self.command:
+            raise AirflowException('You must define a command.')
+
+        # Pull the container if asked, and ensure not a binary file
+        if self.force_pull and not os.path.exists(self.image):
+            self.log.info('Pulling container %s', self.image)
+            image, lines = self.cli.pull(self.image, stream=True)
+            for line in lines:
+                self.log.info(line)
+
+            # Move the container to where it's desired
+            if self.pull_folder is not None:
+                self.image = os.path.join(self.pull_folder, os.path.basename(image))
+                shutil.move(image, self.image)
+
+        # Prepare list of binds
+        for bind in self.volumes:
+            self.options = self.options + ['--bind', bind]
+
+        # Does the user want a custom working directory?
+        if self.working_dir is not None:
+            self.options = self.options + ['--workdir', self.working_dir]
+
+        # Export environment before instance is run
+        for enkey, envar in self.environment.items():
+            self.log.debug('Exporting %s=%s', envar, enkey)
+            os.putenv(enkey, envar)
+            os.environ[enkey] = envar
+
+        # Create a container instance
+        self.log.debug('Options include: %s', self.options)
+        self.instance = self.cli.instance(self.image,
+                                          options=self.options,
+                                          args=self.start_command,
+                                          start=False)
+
+        self.instance.start()
+        self.log.info(self.instance.cmd)
+        self.log.info('Created instance %s from %s', self.instance, self.image)
+
+        self.log.info('Running command %s', self.get_command())
+        self.cli.quiet = True
+        result = self.cli.execute(self.instance,
+                                  self.get_command(),
+                                  return_result=True)
+
+        # Stop the instance
+        self.log.info('Stopping instance %s', self.instance)
+        self.instance.stop()
+
+        if self.auto_remove is True:
+            if os.path.exists(self.image):
+                shutil.rmtree(self.image)
+
+        # If the container failed, raise the exception
+        if result['return_code'] != 0:
+            message = result['message']
+            raise AirflowException('Singularity failed: %s' % message)
+
+        self.log.info('Output from command %s', result['message'])
+
+    def get_command(self):
+        if self.command is not None and self.command.strip().find('[') == 0:
+            commands = ast.literal_eval(self.command)
+        else:
+            commands = self.command
+        return commands
+
+    def on_kill(self):
+        if self.instance is not None:
+            self.log.info('Stopping Singularity instance')
+            self.instance.stop()
+
+            # If an image exists, clean it up
+            if self.auto_remove is True:
+                if os.path.exists(self.image):
+                    shutil.rmtree(self.image)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1987,7 +1987,7 @@ class ConfigurationView(AirflowBaseView):
 ######################################################################################
 
 class DagFilter(BaseFilter):
-    def apply(self, query, func): # noqa
+    def apply(self, query, func):  # noqa
         if appbuilder.sm.has_all_dags_access():
             return query
         filter_dag_ids = appbuilder.sm.get_accessible_dag_ids()

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -1071,6 +1071,12 @@ These integrations allow you to perform various operations using various softwar
      - :mod:`airflow.operators.sqlite_operator`
      -
 
+   * - `Singularity <https://sylabs.io/docs/>`__
+     -
+     -
+     - :mod:`airflow.contrib.operators.singularity_operator`
+     -
+
 
 Transfer operators and hooks
 ''''''''''''''''''''''''''''

--- a/setup.py
+++ b/setup.py
@@ -254,6 +254,7 @@ samba = ['pysmbclient>=0.1.3']
 segment = ['analytics-python>=1.2.9']
 sendgrid = ['sendgrid>=5.2.0,<6']
 sentry = ['sentry-sdk>=0.8.0', "blinker>=1.1"]
+singularity = ['spython>=0.0.56']
 slack = ['slackclient>=1.0.0,<2.0.0']
 mongo = ['pymongo>=3.6.0', 'dnspython>=1.13.0,<2.0.0']
 snowflake = ['snowflake-connector-python>=1.5.2',
@@ -315,7 +316,7 @@ else:
 
 devel_minreq = devel + kubernetes + mysql + doc + password + cgroups
 devel_hadoop = devel_minreq + hive + hdfs + webhdfs + kerberos
-devel_all = (sendgrid + devel + all_dbs + doc + samba + slack + oracle +
+devel_all = (sendgrid + devel + all_dbs + doc + samba + slack + singularity + oracle +
              docker + ssh + kubernetes + celery + redis + gcp + grpc +
              datadog + zendesk + jdbc + ldap + kerberos + password + webhdfs + jenkins +
              druid + pinot + segment + snowflake + elasticsearch + sentry +
@@ -450,6 +451,7 @@ def do_setup():
             'sendgrid': sendgrid,
             'sentry': sentry,
             'segment': segment,
+            'singularity': singularity,
             'slack': slack,
             'snowflake': snowflake,
             'ssh': ssh,

--- a/tests/contrib/hooks/test_cassandra_hook.py
+++ b/tests/contrib/hooks/test_cassandra_hook.py
@@ -84,7 +84,7 @@ class TestCassandraHook(unittest.TestCase):
                                    DCAwareRoundRobinPolicy)
 
         # test WhiteListRoundRobinPolicy with args
-        fake_addr_info = [['family', 'sockettype', 'proto', 'canonname', ('2606:2800:220:1:248:1893:25c8:1946', 80, 0, 0)]] # noqa
+        fake_addr_info = [['family', 'sockettype', 'proto', 'canonname', ('2606:2800:220:1:248:1893:25c8:1946', 80, 0, 0)]]  # noqa
         with patch('socket.getaddrinfo', return_value=fake_addr_info):
             self._assert_get_lb_policy('WhiteListRoundRobinPolicy',
                                        {'hosts': ['host1', 'host2']},

--- a/tests/contrib/operators/test_singularity_operator.py
+++ b/tests/contrib/operators/test_singularity_operator.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+import six
+
+from parameterized import parameterized
+from spython.instance import Instance
+from airflow import AirflowException
+
+try:
+    from airflow.contrib.operators.singularity_operator import SingularityOperator
+except ImportError:
+    pass
+
+from tests.compat import mock
+
+
+class SingularityOperatorTestCase(unittest.TestCase):
+    @mock.patch('airflow.contrib.operators.singularity_operator.Client')
+    def test_execute(self, client_mock):
+        instance = mock.Mock(autospec=Instance, **{
+            'start.return_value': 0,
+            'stop.return_value': 0,
+        })
+
+        client_mock.instance.return_value = instance
+        client_mock.execute.return_value = {'return_code': 0,
+                                            'message': 'message'}
+
+        task = SingularityOperator(
+            task_id='task-id',
+            image="awesome-image",
+            command="awesome-command"
+        )
+        task.execute({})
+
+        client_mock.instance.assert_called_once_with("awesome-image",
+                                                     options=[],
+                                                     args=None,
+                                                     start=False)
+
+        client_mock.execute.assert_called_once_with(mock.ANY,
+                                                    "awesome-command",
+                                                    return_result=True)
+
+        execute_args, _ = client_mock.execute.call_args
+        self.assertIs(execute_args[0], instance)
+
+        instance.start.assert_called_once_with()
+        instance.stop.assert_called_once_with()
+
+    @parameterized.expand([
+        ("",),
+        (None,),
+    ])
+    def test_command_is_required(self, command):
+        task = SingularityOperator(
+            task_id='task-id',
+            image="awesome-image",
+            command=command
+        )
+        with six.assertRaisesRegex(self, AirflowException, "You must define a command."):
+            task.execute({})
+
+    @mock.patch('airflow.contrib.operators.singularity_operator.shutil')
+    @mock.patch('airflow.contrib.operators.singularity_operator.os.path.exists')
+    @mock.patch('airflow.contrib.operators.singularity_operator.Client')
+    def test_image_should_be_pulled_when_not_exists(self, client_mock, exists_mock, shutil_mock):
+        instance = mock.Mock(autospec=Instance, **{
+            'start.return_value': 0,
+            'stop.return_value': 0,
+        })
+
+        client_mock.pull.return_value = 'pull-file', ''
+        client_mock.instance.return_value = instance
+        client_mock.execute.return_value = {'return_code': 0,
+                                            'message': 'message'}
+        exists_mock.return_value = False
+
+        task = SingularityOperator(
+            task_id='task-id',
+            image="awesome-image",
+            command="awesome-command",
+            pull_folder="/tmp/path",
+            force_pull=True
+        )
+        task.execute({})
+
+        client_mock.instance.assert_called_once_with(
+            "/tmp/path/pull-file", options=[], args=None, start=False
+        )
+        client_mock.pull.assert_called_once_with("awesome-image", stream=True)
+        client_mock.execute.assert_called_once_with(mock.ANY,
+                                                    "awesome-command",
+                                                    return_result=True)
+
+        shutil_mock.move.assert_called_once_with("pull-file", "/tmp/path/pull-file")
+
+    @parameterized.expand([
+        (None, [], ),
+        ([], [], ),
+        (["AAA"], ['--bind', 'AAA'], ),
+        (["AAA", "BBB"], ['--bind', 'AAA', '--bind', 'BBB'], ),
+        (["AAA", "BBB", "CCC"], ['--bind', 'AAA', '--bind', 'BBB', '--bind', 'CCC'], ),
+
+    ])
+    @mock.patch('airflow.contrib.operators.singularity_operator.Client')
+    def test_bind_options(self, volumes, expected_options, client_mock):
+        instance = mock.Mock(autospec=Instance, **{
+            'start.return_value': 0,
+            'stop.return_value': 0,
+        })
+        client_mock.pull.return_value = 'pull-file', ''
+        client_mock.instance.return_value = instance
+        client_mock.execute.return_value = {'return_code': 0,
+                                            'message': 'message'}
+
+        task = SingularityOperator(
+            task_id='task-id',
+            image="awesome-image",
+            command="awesome-command",
+            force_pull=True,
+            volumes=volumes
+        )
+        task.execute({})
+
+        client_mock.instance.assert_called_once_with(
+            "awesome-image", options=expected_options, args=None, start=False
+        )
+
+    @parameterized.expand([
+        (None, [], ),
+        ("", ['--workdir', ''], ),
+        ("/work-dir/", ['--workdir', '/work-dir/'], ),
+    ])
+    @mock.patch('airflow.contrib.operators.singularity_operator.Client')
+    def test_working_dir(self, working_dir, expected_working_dir, client_mock):
+        instance = mock.Mock(autospec=Instance, **{
+            'start.return_value': 0,
+            'stop.return_value': 0,
+        })
+        client_mock.pull.return_value = 'pull-file', ''
+        client_mock.instance.return_value = instance
+        client_mock.execute.return_value = {'return_code': 0,
+                                            'message': 'message'}
+
+        task = SingularityOperator(
+            task_id='task-id',
+            image="awesome-image",
+            command="awesome-command",
+            force_pull=True,
+            working_dir=working_dir
+        )
+        task.execute({})
+
+        client_mock.instance.assert_called_once_with(
+            "awesome-image", options=expected_working_dir, args=None, start=False
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/contrib/operators/test_singularity_operator.py
+++ b/tests/contrib/operators/test_singularity_operator.py
@@ -18,18 +18,18 @@
 # under the License.
 
 import unittest
-import six
 
+import six
 from parameterized import parameterized
 from spython.instance import Instance
+
 from airflow import AirflowException
+from tests.compat import mock
 
 try:
     from airflow.contrib.operators.singularity_operator import SingularityOperator
 except ImportError:
     pass
-
-from tests.compat import mock
 
 
 class SingularityOperatorTestCase(unittest.TestCase):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
