### PR TITLE
Airflow 6373 pylint utils 2

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -41,6 +41,11 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Chain and cross_downstream moved from helpers to BaseOperator
+
+The chain and cross_downstream methods are now static methods in BaseOperator and not
+top-level methods in airflow.utils.helpers module.
+
 ### Logging configuration has been moved to new section
 
 The following configurations have been moved from `[core]` to the new `[logging]` section.

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -30,7 +30,7 @@ from airflow.kubernetes.volume import Volume
 from airflow.kubernetes.volume_mount import VolumeMount
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
-from airflow.utils.helpers import validate_key
+from airflow.utils.key_validation import validate_key
 from airflow.utils.state import State
 from airflow.version import version as airflow_version
 

--- a/airflow/example_dags/example_short_circuit_operator.py
+++ b/airflow/example_dags/example_short_circuit_operator.py
@@ -18,15 +18,15 @@
 # under the License.
 
 """Example DAG demonstrating the usage of the ShortCircuitOperator."""
-
-import airflow.utils.helpers
 from airflow.models import DAG
+from airflow.models.baseoperator import BaseOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import ShortCircuitOperator
+from airflow.utils import dates
 
 args = {
     'owner': 'airflow',
-    'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': dates.days_ago(2),
 }
 
 dag = DAG(dag_id='example_short_circuit_operator', default_args=args)
@@ -46,5 +46,5 @@ cond_false = ShortCircuitOperator(
 ds_true = [DummyOperator(task_id='true_' + str(i), dag=dag) for i in [1, 2]]
 ds_false = [DummyOperator(task_id='false_' + str(i), dag=dag) for i in [1, 2]]
 
-airflow.utils.helpers.chain(cond_true, *ds_true)
-airflow.utils.helpers.chain(cond_false, *ds_false)
+BaseOperator.chain(cond_true, *ds_true)
+BaseOperator.chain(cond_false, *ds_false)

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -26,7 +26,9 @@ import sys
 import warnings
 from abc import ABCMeta, abstractmethod
 from datetime import datetime, timedelta
-from typing import Any, Callable, ClassVar, Dict, FrozenSet, Iterable, List, Optional, Set, Tuple, Type, Union
+from typing import (
+    Any, Callable, ClassVar, Dict, FrozenSet, Iterable, List, Optional, Set, Tuple, Type, Union, cast,
+)
 
 import attr
 import jinja2
@@ -49,7 +51,7 @@ from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 from airflow.utils import timezone
 from airflow.utils.db import provide_session
 from airflow.utils.decorators import apply_defaults
-from airflow.utils.helpers import validate_key
+from airflow.utils.key_validation import validate_key
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.operator_resources import Resources
 from airflow.utils.trigger_rule import TriggerRule
@@ -670,6 +672,7 @@ class BaseOperator(Operator, LoggingMixin):
 
         for k, v in self.__dict__.items():
             if k not in shallow_copy:
+                # noinspection PyArgumentList
                 setattr(result, k, copy.deepcopy(v, memo))
             else:
                 setattr(result, k, copy.copy(v))
@@ -862,6 +865,7 @@ class BaseOperator(Operator, LoggingMixin):
             tasks += [
                 t.task_id for t in self.get_flat_relatives(upstream=False)]
 
+        # noinspection PyUnresolvedReferences
         qry = qry.filter(TaskInstance.task_id.in_(tasks))
 
         count = qry.count()
@@ -1115,6 +1119,85 @@ class BaseOperator(Operator, LoggingMixin):
                 } | {'_task_type', 'subdag', 'ui_color', 'ui_fgcolor', 'template_fields'})
 
         return cls.__serialized_fields
+
+    @staticmethod
+    def chain(*tasks: Union['BaseOperator', List['BaseOperator']]):
+        r"""
+        Given a number of tasks, builds a dependency chain.
+        Support mix airflow.models.BaseOperator and List[airflow.models.BaseOperator].
+        If you want to chain between two List[airflow.models.BaseOperator], have to
+        make sure they have same length.
+
+        chain(t1, [t2, t3], [t4, t5], t6)
+
+        is equivalent to
+
+          / -> t2 -> t4 \
+        t1               -> t6
+          \ -> t3 -> t5 /
+
+        t1.set_downstream(t2)
+        t1.set_downstream(t3)
+        t2.set_downstream(t4)
+        t3.set_downstream(t5)
+        t4.set_downstream(t6)
+        t5.set_downstream(t6)
+
+        :param tasks: List of tasks or List[airflow.models.BaseOperator] to set dependencies
+        :type tasks: List[airflow.models.BaseOperator] or airflow.models.BaseOperator
+        """
+        for index, up_task in enumerate(tasks[:-1]):
+            down_task = tasks[index + 1]
+            if isinstance(up_task, BaseOperator):
+                up_task.set_downstream(down_task)
+                continue
+            if isinstance(down_task, BaseOperator):
+                down_task.set_upstream(up_task)
+                continue
+            if not isinstance(up_task, List) or not isinstance(down_task, List):
+                raise TypeError(
+                    'Chain not supported between instances of {up_type} and {down_type}'.format(
+                        up_type=type(up_task), down_type=type(down_task)))
+            up_task_list = cast(List[BaseOperator], up_task)
+            down_task_list = cast(List[BaseOperator], down_task)
+            if len(up_task_list) != len(down_task_list):
+                raise AirflowException(
+                    f'Chain not supported different length Iterable '
+                    f'but get {len(up_task_list)} and {len(down_task_list)}')
+            for up_t, down_t in zip(up_task_list, down_task_list):
+                up_t.set_downstream(down_t)
+
+    @staticmethod
+    def cross_downstream(from_tasks: List['BaseOperator'],
+                         to_tasks: Union['BaseOperator', List['BaseOperator']]):
+        r"""
+        Set downstream dependencies for all tasks in from_tasks to all tasks in to_tasks.
+        E.g.: cross_downstream(from_tasks=[t1, t2, t3], to_tasks=[t4, t5, t6])
+        Is equivalent to:
+
+        t1 --> t4
+           \ /
+        t2 -X> t5
+           / \
+        t3 --> t6
+
+        t1.set_downstream(t4)
+        t1.set_downstream(t5)
+        t1.set_downstream(t6)
+        t2.set_downstream(t4)
+        t2.set_downstream(t5)
+        t2.set_downstream(t6)
+        t3.set_downstream(t4)
+        t3.set_downstream(t5)
+        t3.set_downstream(t6)
+
+        :param from_tasks: List of tasks to start from.
+        :type from_tasks: List[airflow.models.BaseOperator]
+        :param to_tasks: List of tasks to set as downstream dependencies.
+        :type to_tasks: List[airflow.models.BaseOperator]
+        """
+        for task in from_tasks:
+            task.set_downstream(to_tasks)
 
 
 @attr.s(auto_attribs=True)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -49,7 +49,7 @@ from airflow.utils import timezone
 from airflow.utils.dates import cron_presets, date_range as utils_date_range
 from airflow.utils.db import provide_session
 from airflow.utils.file import correct_maybe_zipped
-from airflow.utils.helpers import validate_key
+from airflow.utils.key_validation import validate_key
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.sqlalchemy import Interval, UtcDateTime
 from airflow.utils.state import State

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -29,36 +29,12 @@ import psutil
 from jinja2 import Template
 
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException
-
-try:
-    # Fix Python > 3.7 deprecation
-    from collections.abc import Iterable
-except ImportError:
-    # Preserve Python < 3.3 compatibility
-    from collections import Iterable
 
 # When killing processes, time to wait after issuing a SIGTERM before issuing a
 # SIGKILL.
 DEFAULT_TIME_TO_WAIT_AFTER_SIGTERM = conf.getint(
     'core', 'KILLED_TASK_CLEANUP_TIME'
 )
-
-KEY_REGEX = re.compile(r'^[\w.-]+$')
-
-
-def validate_key(k, max_length=250):
-    if not isinstance(k, str):
-        raise TypeError("The key has to be a string")
-    elif len(k) > max_length:
-        raise AirflowException(
-            "The key has to be less than {0} characters".format(max_length))
-    elif not KEY_REGEX.match(k):
-        raise AirflowException(
-            "The key ({k}) has to be made of alphanumeric characters, dashes, "
-            "dots and underscores exclusively".format(k=k))
-    else:
-        return True
 
 
 def alchemy_to_dict(obj):
@@ -140,83 +116,6 @@ def as_flattened_list(iterable):
     ['blue', 'red', 'green', 'yellow', 'pink']
     """
     return [e for i in iterable for e in i]
-
-
-def chain(*tasks):
-    r"""
-    Given a number of tasks, builds a dependency chain.
-    Support mix airflow.models.BaseOperator and List[airflow.models.BaseOperator].
-    If you want to chain between two List[airflow.models.BaseOperator], have to
-    make sure they have same length.
-
-    chain(t1, [t2, t3], [t4, t5], t6)
-
-    is equivalent to
-
-      / -> t2 -> t4 \
-    t1               -> t6
-      \ -> t3 -> t5 /
-
-    t1.set_downstream(t2)
-    t1.set_downstream(t3)
-    t2.set_downstream(t4)
-    t3.set_downstream(t5)
-    t4.set_downstream(t6)
-    t5.set_downstream(t6)
-
-    :param tasks: List of tasks or List[airflow.models.BaseOperator] to set dependencies
-    :type tasks: List[airflow.models.BaseOperator] or airflow.models.BaseOperator
-    """
-    from airflow.models.baseoperator import BaseOperator
-    for index, up_task in enumerate(tasks[:-1]):
-        down_task = tasks[index + 1]
-        if isinstance(up_task, BaseOperator):
-            up_task.set_downstream(down_task)
-        elif isinstance(down_task, BaseOperator):
-            down_task.set_upstream(up_task)
-        else:
-            if not isinstance(up_task, Iterable) or not isinstance(down_task, Iterable):
-                raise TypeError(
-                    'Chain not supported between instances of {up_type} and {down_type}'.format(
-                        up_type=type(up_task), down_type=type(down_task)))
-            elif len(up_task) != len(down_task):
-                raise AirflowException(
-                    'Chain not supported different length Iterable but get {up_len} and {down_len}'.format(
-                        up_len=len(up_task), down_len=len(down_task)))
-            else:
-                for up, down in zip(up_task, down_task):
-                    up.set_downstream(down)
-
-
-def cross_downstream(from_tasks, to_tasks):
-    r"""
-    Set downstream dependencies for all tasks in from_tasks to all tasks in to_tasks.
-    E.g.: cross_downstream(from_tasks=[t1, t2, t3], to_tasks=[t4, t5, t6])
-    Is equivalent to:
-
-    t1 --> t4
-       \ /
-    t2 -X> t5
-       / \
-    t3 --> t6
-
-    t1.set_downstream(t4)
-    t1.set_downstream(t5)
-    t1.set_downstream(t6)
-    t2.set_downstream(t4)
-    t2.set_downstream(t5)
-    t2.set_downstream(t6)
-    t3.set_downstream(t4)
-    t3.set_downstream(t5)
-    t3.set_downstream(t6)
-
-    :param from_tasks: List of tasks to start from.
-    :type from_tasks: List[airflow.models.BaseOperator]
-    :param to_tasks: List of tasks to set as downstream dependencies.
-    :type to_tasks: List[airflow.models.BaseOperator]
-    """
-    for task in from_tasks:
-        task.set_downstream(to_tasks)
 
 
 def pprinttable(rows):

--- a/airflow/utils/key_validation.py
+++ b/airflow/utils/key_validation.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Validates keys used in various places in Airflow code"""
+import re
+
+from airflow import AirflowException
+
+
+def validate_key(k, max_length=250):
+    """
+    Validates value used as a key.
+    """
+    if not isinstance(k, str):
+        raise TypeError("The key has to be a string")
+    elif len(k) > max_length:
+        raise AirflowException(
+            "The key has to be less than {0} characters".format(max_length))
+    elif not KEY_REGEX.match(k):
+        raise AirflowException(
+            "The key ({k}) has to be made of alphanumeric characters, dashes, "
+            "dots and underscores exclusively".format(k=k))
+    else:
+        return True
+
+
+KEY_REGEX = re.compile(r'^[\w.-]+$')

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -17,15 +17,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import datetime
 import unittest
 import uuid
+from datetime import date, datetime
 from unittest import mock
 
 import jinja2
 from parameterized import parameterized
 
+from airflow.exceptions import AirflowException
 from airflow.models import DAG
+from airflow.models.baseoperator import BaseOperator
 from airflow.operators.dummy_operator import DummyOperator
 from tests.models import DEFAULT_DATE
 from tests.test_utils.mock_operators import MockNamedTuple, MockOperator
@@ -81,8 +83,8 @@ class TestBaseOperator(unittest.TestCase):
                 {"foo": "bar"},
                 {"key_{{ foo }}_1": 1, "key_2": "bar_2"},
             ),
-            (datetime.date(2018, 12, 6), {"foo": "bar"}, datetime.date(2018, 12, 6)),
-            (datetime.datetime(2018, 12, 6, 10, 55), {"foo": "bar"}, datetime.datetime(2018, 12, 6, 10, 55)),
+            (date(2018, 12, 6), {"foo": "bar"}, date(2018, 12, 6)),
+            (datetime(2018, 12, 6, 10, 55), {"foo": "bar"}, datetime(2018, 12, 6, 10, 55)),
             (MockNamedTuple("{{ foo }}_1", "{{ foo }}_2"), {"foo": "bar"}, MockNamedTuple("bar_1", "bar_2")),
             ({"{{ foo }}_1", "{{ foo }}_2"}, {"foo": "bar"}, {"bar_1", "bar_2"}),
             (None, {}, None),
@@ -241,7 +243,44 @@ class TestBaseOperator(unittest.TestCase):
         task = DummyOperator(task_id="default-resources")
         self.assertIsNone(task.resources)
 
+    # noinspection PyUnresolvedReferences
     def test_custom_resources(self):
         task = DummyOperator(task_id="custom-resources", resources={"cpus": 1, "ram": 1024})
         self.assertEqual(task.resources.cpus.qty, 1)
         self.assertEqual(task.resources.ram.qty, 1024)
+
+    def test_cross_downstream(self):
+        """Test if all dependencies between tasks are all set correctly."""
+        dag = DAG(dag_id="test_dag", start_date=datetime.now())
+        start_tasks = [DummyOperator(task_id="t{i}".format(i=i), dag=dag) for i in range(1, 4)]
+        end_tasks = [DummyOperator(task_id="t{i}".format(i=i), dag=dag) for i in range(4, 7)]
+        BaseOperator.cross_downstream(from_tasks=start_tasks, to_tasks=end_tasks)
+
+        for start_task in start_tasks:
+            self.assertCountEqual(start_task.get_direct_relatives(upstream=False), end_tasks)
+
+    def test_chain(self):
+        dag = DAG(dag_id='test_chain', start_date=datetime.now())
+        [op1, op2, op3, op4, op5, op6] = [
+            DummyOperator(task_id='t{i}'.format(i=i), dag=dag)
+            for i in range(1, 7)
+        ]
+        BaseOperator.chain(op1, [op2, op3], [op4, op5], op6)
+
+        self.assertCountEqual([op2, op3], op1.get_direct_relatives(upstream=False))
+        self.assertEqual([op4], op2.get_direct_relatives(upstream=False))
+        self.assertEqual([op5], op3.get_direct_relatives(upstream=False))
+        self.assertCountEqual([op4, op5], op6.get_direct_relatives(upstream=True))
+
+    def test_chain_not_support_type(self):
+        dag = DAG(dag_id='test_chain', start_date=datetime.now())
+        [op1, op2] = [DummyOperator(task_id='t{i}'.format(i=i), dag=dag) for i in range(1, 3)]
+        with self.assertRaises(TypeError):
+            # noinspection PyTypeChecker
+            BaseOperator.chain([op1, op2], 1)
+
+    def test_chain_different_length_iterable(self):
+        dag = DAG(dag_id='test_chain', start_date=datetime.now())
+        [op1, op2, op3, op4, op5] = [DummyOperator(task_id='t{i}'.format(i=i), dag=dag) for i in range(1, 6)]
+        with self.assertRaises(AirflowException):
+            BaseOperator.chain([op1, op2], [op3, op4, op5])


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
