### PR TITLE
[AIRFLOW-6109] [AIP-21] Rename GCP function operators and hook

### DIFF
--- a/airflow/contrib/hooks/gcp_function_hook.py
+++ b/airflow/contrib/hooks/gcp_function_hook.py
@@ -20,8 +20,7 @@
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.gcp.hooks.functions import CloudFunctionsHook  # noqa
+from airflow.gcp.hooks.functions import CloudFunctionsHook
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.functions`.",

--- a/airflow/contrib/operators/gcp_function_operator.py
+++ b/airflow/contrib/operators/gcp_function_operator.py
@@ -20,12 +20,41 @@
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.gcp.operators.functions import (  # # noqa
-    GcfFunctionDeleteOperator, GcfFunctionDeployOperator, ZipPathPreprocessor,
+from airflow.gcp.operators.functions import (
+    CloudFunctionDeleteFunctionOperator, CloudFunctionDeployFunctionOperator,
 )
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.functions`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class GcfFunctionDeleteOperator(CloudFunctionDeleteFunctionOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.function.CloudFunctionDeleteFunctionOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.function.CloudFunctionDeleteFunctionOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class GcfFunctionDeployOperator(CloudFunctionDeployFunctionOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.function.CloudFunctionDeployFunctionOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.function.CloudFunctionDeployFunctionOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/gcp/example_dags/example_functions.py
+++ b/airflow/gcp/example_dags/example_functions.py
@@ -45,7 +45,7 @@ import os
 
 from airflow import models
 from airflow.gcp.operators.functions import (
-    GcfFunctionDeleteOperator, GcfFunctionDeployOperator, GcfFunctionInvokeOperator,
+    CloudFunctionDeleteFunctionOperator, CloudFunctionDeployFunctionOperator, CloudFunctionInvokeOperator,
 )
 from airflow.utils import dates
 
@@ -109,7 +109,7 @@ with models.DAG(
     schedule_interval=None  # Override to match your needs
 ) as dag:
     # [START howto_operator_gcf_deploy]
-    deploy_task = GcfFunctionDeployOperator(
+    deploy_task = CloudFunctionDeployFunctionOperator(
         task_id="gcf_deploy_task",
         project_id=GCP_PROJECT_ID,
         location=GCP_LOCATION,
@@ -118,7 +118,7 @@ with models.DAG(
     )
     # [END howto_operator_gcf_deploy]
     # [START howto_operator_gcf_deploy_no_project_id]
-    deploy2_task = GcfFunctionDeployOperator(
+    deploy2_task = CloudFunctionDeployFunctionOperator(
         task_id="gcf_deploy2_task",
         location=GCP_LOCATION,
         body=body,
@@ -126,7 +126,7 @@ with models.DAG(
     )
     # [END howto_operator_gcf_deploy_no_project_id]
     # [START howto_operator_gcf_invoke_function]
-    invoke_task = GcfFunctionInvokeOperator(
+    invoke_task = CloudFunctionInvokeOperator(
         task_id="invoke_task",
         project_id=GCP_PROJECT_ID,
         location=GCP_LOCATION,
@@ -135,7 +135,7 @@ with models.DAG(
     )
     # [END howto_operator_gcf_invoke_function]
     # [START howto_operator_gcf_delete]
-    delete_task = GcfFunctionDeleteOperator(
+    delete_task = CloudFunctionDeleteFunctionOperator(
         task_id="gcf_delete_task",
         name=FUNCTION_NAME
     )

--- a/airflow/gcp/operators/functions.py
+++ b/airflow/gcp/operators/functions.py
@@ -82,7 +82,7 @@ CLOUD_FUNCTION_VALIDATION = [
 ]  # type: List[Dict[str, Any]]
 
 
-class GcfFunctionDeployOperator(BaseOperator):
+class CloudFunctionDeployFunctionOperator(BaseOperator):
     """
     Creates a function in Google Cloud Functions.
     If a function with this name already exists, it will be updated.
@@ -292,7 +292,7 @@ FUNCTION_NAME_PATTERN = '^projects/[^/]+/locations/[^/]+/functions/[^/]+$'
 FUNCTION_NAME_COMPILED_PATTERN = re.compile(FUNCTION_NAME_PATTERN)
 
 
-class GcfFunctionDeleteOperator(BaseOperator):
+class CloudFunctionDeleteFunctionOperator(BaseOperator):
     """
     Deletes the specified function from Google Cloud Functions.
 
@@ -346,7 +346,7 @@ class GcfFunctionDeleteOperator(BaseOperator):
                 raise e
 
 
-class GcfFunctionInvokeOperator(BaseOperator):
+class CloudFunctionInvokeOperator(BaseOperator):
     """
     Invokes a deployed Cloud Function. To be used for testing
     purposes as very limited traffic is allowed.

--- a/tests/gcp/operators/test_functions.py
+++ b/tests/gcp/operators/test_functions.py
@@ -26,7 +26,8 @@ from parameterized import parameterized
 
 from airflow import AirflowException
 from airflow.gcp.operators.functions import (
-    FUNCTION_NAME_PATTERN, GcfFunctionDeleteOperator, GcfFunctionDeployOperator, GcfFunctionInvokeOperator,
+    FUNCTION_NAME_PATTERN, CloudFunctionDeleteFunctionOperator, CloudFunctionDeployFunctionOperator,
+    CloudFunctionInvokeOperator,
 )
 from airflow.version import version
 
@@ -74,7 +75,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
     def test_body_empty_or_missing_fields(self, body, message, mock_hook):
         mock_hook.return_value.upload_function_zip.return_value = 'https://uploadUrl'
         with self.assertRaises(AirflowException) as cm:
-            op = GcfFunctionDeployOperator(
+            op = CloudFunctionDeployFunctionOperator(
                 project_id="test_project_id",
                 location="test_region",
                 body=body,
@@ -89,7 +90,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         mock_hook.return_value.get_function.side_effect = mock.Mock(
             side_effect=HttpError(resp=MOCK_RESP_404, content=b'not found'))
         mock_hook.return_value.create_new_function.return_value = True
-        op = GcfFunctionDeployOperator(
+        op = CloudFunctionDeployFunctionOperator(
             project_id=GCP_PROJECT_ID,
             location=GCP_LOCATION,
             body=deepcopy(VALID_BODY),
@@ -115,7 +116,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
     def test_update_function_if_exists(self, mock_hook):
         mock_hook.return_value.get_function.return_value = True
         mock_hook.return_value.update_function.return_value = True
-        op = GcfFunctionDeployOperator(
+        op = CloudFunctionDeployFunctionOperator(
             project_id=GCP_PROJECT_ID,
             location=GCP_LOCATION,
             body=deepcopy(VALID_BODY),
@@ -140,7 +141,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
     def test_empty_project_id_is_ok(self, mock_hook):
         mock_hook.return_value.get_function.side_effect = \
             HttpError(resp=MOCK_RESP_404, content=b'not found')
-        operator = GcfFunctionDeployOperator(
+        operator = CloudFunctionDeployFunctionOperator(
             location="test_region",
             body=deepcopy(VALID_BODY),
             task_id="id"
@@ -159,7 +160,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.functions.CloudFunctionsHook')
     def test_empty_location(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            GcfFunctionDeployOperator(
+            CloudFunctionDeployFunctionOperator(
                 project_id="test_project_id",
                 location="",
                 body=None,
@@ -171,7 +172,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.functions.CloudFunctionsHook')
     def test_empty_body(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            GcfFunctionDeployOperator(
+            CloudFunctionDeployFunctionOperator(
                 project_id="test_project_id",
                 location="test_region",
                 body=None,
@@ -188,7 +189,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         mock_hook.return_value.create_new_function.return_value = True
         body = deepcopy(VALID_BODY)
         body['runtime'] = runtime
-        op = GcfFunctionDeployOperator(
+        op = CloudFunctionDeployFunctionOperator(
             project_id="test_project_id",
             location="test_region",
             body=body,
@@ -212,7 +213,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         mock_hook.return_value.create_new_function.return_value = True
         body = deepcopy(VALID_BODY)
         body['network'] = network
-        op = GcfFunctionDeployOperator(
+        op = CloudFunctionDeployFunctionOperator(
             project_id="test_project_id",
             location="test_region",
             body=body,
@@ -235,7 +236,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         mock_hook.return_value.create_new_function.return_value = True
         body = deepcopy(VALID_BODY)
         body['labels'] = labels
-        op = GcfFunctionDeployOperator(
+        op = CloudFunctionDeployFunctionOperator(
             project_id="test_project_id",
             location="test_region",
             body=body,
@@ -253,7 +254,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
             "name": "function_name",
             "some_invalid_body_field": "some_invalid_body_field_value"
         }
-        op = GcfFunctionDeployOperator(
+        op = CloudFunctionDeployFunctionOperator(
             project_id="test_project_id",
             location="test_region",
             body=body,
@@ -271,7 +272,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         body = deepcopy(VALID_BODY)
         body['name'] = ''
         with self.assertRaises(AirflowException) as cm:
-            op = GcfFunctionDeployOperator(
+            op = CloudFunctionDeployFunctionOperator(
                 project_id="test_project_id",
                 location="test_region",
                 body=body,
@@ -307,7 +308,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         body = deepcopy(VALID_BODY)
         body[key] = value
         with self.assertRaises(AirflowException) as cm:
-            op = GcfFunctionDeployOperator(
+            op = CloudFunctionDeployFunctionOperator(
                 project_id="test_project_id",
                 location="test_region",
                 body=body,
@@ -361,7 +362,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         zip_path = source_code.pop('zip_path', None)
         body.update(source_code)
         with self.assertRaises(AirflowException) as cm:
-            op = GcfFunctionDeployOperator(
+            op = CloudFunctionDeployFunctionOperator(
                 project_id="test_project_id",
                 location="test_region",
                 body=body,
@@ -398,7 +399,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         zip_path = source_code.pop('zip_path', None)
         body.update(source_code)
         if project_id:
-            op = GcfFunctionDeployOperator(
+            op = CloudFunctionDeployFunctionOperator(
                 project_id="test_project_id",
                 location="test_region",
                 body=body,
@@ -406,7 +407,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
                 zip_path=zip_path
             )
         else:
-            op = GcfFunctionDeployOperator(
+            op = CloudFunctionDeployFunctionOperator(
                 location="test_region",
                 body=body,
                 task_id="id",
@@ -458,7 +459,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         body.pop('eventTrigger', None)
         body.update(trigger)
         with self.assertRaises(AirflowException) as cm:
-            op = GcfFunctionDeployOperator(
+            op = CloudFunctionDeployFunctionOperator(
                 project_id="test_project_id",
                 location="test_region",
                 body=body,
@@ -496,7 +497,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         body.pop('httpsTrigger', None)
         body.pop('eventTrigger', None)
         body.update(trigger)
-        op = GcfFunctionDeployOperator(
+        op = CloudFunctionDeployFunctionOperator(
             project_id="test_project_id",
             location="test_region",
             body=body,
@@ -520,7 +521,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         mock_hook.return_value.create_new_function.return_value = True
         body = deepcopy(VALID_BODY)
         body['extra_parameter'] = 'extra'
-        op = GcfFunctionDeployOperator(
+        op = CloudFunctionDeployFunctionOperator(
             project_id="test_project_id",
             location="test_region",
             body=body,
@@ -552,7 +553,7 @@ class TestGcfFunctionDelete(unittest.TestCase):
     def test_delete_execute(self, mock_hook):
         mock_hook.return_value.delete_function.return_value = \
             self._DELETE_FUNCTION_EXPECTED
-        op = GcfFunctionDeleteOperator(
+        op = CloudFunctionDeleteFunctionOperator(
             name=self._FUNCTION_NAME,
             task_id="id"
         )
@@ -566,7 +567,7 @@ class TestGcfFunctionDelete(unittest.TestCase):
 
     @mock.patch('airflow.gcp.operators.functions.CloudFunctionsHook')
     def test_correct_name(self, mock_hook):
-        op = GcfFunctionDeleteOperator(
+        op = CloudFunctionDeleteFunctionOperator(
             name="projects/project_name/locations/project_location/functions"
                  "/function_name",
             task_id="id"
@@ -578,7 +579,7 @@ class TestGcfFunctionDelete(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.functions.CloudFunctionsHook')
     def test_invalid_name(self, mock_hook):
         with self.assertRaises(AttributeError) as cm:
-            op = GcfFunctionDeleteOperator(
+            op = CloudFunctionDeleteFunctionOperator(
                 name="invalid_name",
                 task_id="id"
             )
@@ -593,7 +594,7 @@ class TestGcfFunctionDelete(unittest.TestCase):
         mock_hook.return_value.delete_function.return_value = \
             self._DELETE_FUNCTION_EXPECTED
         with self.assertRaises(AttributeError) as cm:
-            GcfFunctionDeleteOperator(
+            CloudFunctionDeleteFunctionOperator(
                 name="",
                 task_id="id"
             )
@@ -603,7 +604,7 @@ class TestGcfFunctionDelete(unittest.TestCase):
 
     @mock.patch('airflow.gcp.operators.functions.CloudFunctionsHook')
     def test_gcf_error_silenced_when_function_doesnt_exist(self, mock_hook):
-        op = GcfFunctionDeleteOperator(
+        op = CloudFunctionDeleteFunctionOperator(
             name=self._FUNCTION_NAME,
             task_id="id"
         )
@@ -618,7 +619,7 @@ class TestGcfFunctionDelete(unittest.TestCase):
 
     @mock.patch('airflow.gcp.operators.functions.CloudFunctionsHook')
     def test_non_404_gcf_error_bubbled_up(self, mock_hook):
-        op = GcfFunctionDeleteOperator(
+        op = CloudFunctionDeleteFunctionOperator(
             name=self._FUNCTION_NAME,
             task_id="id"
         )
@@ -648,7 +649,7 @@ class TestGcfFunctionInvokeOperator(unittest.TestCase):
         api_version = 'test'
         gcp_conn_id = 'test_conn'
 
-        op = GcfFunctionInvokeOperator(
+        op = CloudFunctionInvokeOperator(
             task_id='test',
             function_id=function_id,
             input_data=payload,

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -364,11 +364,11 @@ OPERATOR = [
         "airflow.contrib.operators.gcp_dlp_operator.CloudDLPUpdateStoredInfoTypeOperator",
     ),
     (
-        "airflow.gcp.operators.functions.GcfFunctionDeleteOperator",
+        "airflow.gcp.operators.functions.CloudFunctionDeleteFunctionOperator",
         "airflow.contrib.operators.gcp_function_operator.GcfFunctionDeleteOperator",
     ),
     (
-        "airflow.gcp.operators.functions.GcfFunctionDeployOperator",
+        "airflow.gcp.operators.functions.CloudFunctionDeployFunctionOperator",
         "airflow.contrib.operators.gcp_function_operator.GcfFunctionDeployOperator",
     ),
     (


### PR DESCRIPTION

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6109
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
