### PR TITLE
[AIRFLOW-6112] [AIP-21] Rename GCP SQL operators and hooks

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -428,8 +428,8 @@ The following table shows changes in import paths.
 |airflow.contrib.hooks.gcp_pubsub_hook.PubSubHook                                                                  |airflow.providers.google.cloud.hooks.pubsub.PubSubHook                                                                        |
 |airflow.contrib.hooks.gcp_speech_to_text_hook.GCPSpeechToTextHook                                                 |airflow.gcp.hooks.speech_to_text.CloudSpeechToTextHook                                                     |
 |airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook                                                           |airflow.gcp.hooks.spanner.SpannerHook                                                                      |
-|airflow.contrib.hooks.gcp_sql_hook.CloudSqlDatabaseHook                                                           |airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook                                                           |
-|airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook                                                                   |airflow.gcp.hooks.cloud_sql.CloudSqlHook                                                                   |
+|airflow.contrib.hooks.gcp_sql_hook.CloudSqlDatabaseHook                                                           |airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook                                                           |
+|airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook                                                                   |airflow.gcp.hooks.cloud_sql.CloudSQLHook                                                                   |
 |airflow.contrib.hooks.gcp_tasks_hook.CloudTasksHook                                                               |airflow.gcp.hooks.tasks.CloudTasksHook                                                                     |
 |airflow.contrib.hooks.gcp_text_to_speech_hook.GCPTextToSpeechHook                                                 |airflow.gcp.hooks.text_to_speech.CloudTextToSpeechHook                                                     |
 |airflow.contrib.hooks.gcp_transfer_hook.GCPTransferServiceHook                                                    |airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook                                    |
@@ -1033,12 +1033,12 @@ Operators involved:
   * GCP Function Operators
     * GcfFunctionDeployOperator
   * GCP Cloud SQL Operators
-    * CloudSqlInstanceCreateOperator
-    * CloudSqlInstancePatchOperator
-    * CloudSqlInstanceDeleteOperator
-    * CloudSqlInstanceDatabaseCreateOperator
-    * CloudSqlInstanceDatabasePatchOperator
-    * CloudSqlInstanceDatabaseDeleteOperator
+    * CloudSQLCreateInstanceOperator
+    * CloudSQLInstancePatchOperator
+    * CloudSQLDeleteInstanceOperator
+    * CloudSQLCreateInstanceDatabaseOperator
+    * CloudSQLPatchInstanceDatabaseOperator
+    * CloudSQLDeleteInstanceDatabaseOperator
 
 Other GCP operators are unaffected.
 

--- a/airflow/contrib/hooks/gcp_sql_hook.py
+++ b/airflow/contrib/hooks/gcp_sql_hook.py
@@ -22,10 +22,30 @@ This module is deprecated. Please use `airflow.gcp.hooks.cloud_sql`.
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.gcp.hooks.cloud_sql import CloudSqlDatabaseHook, CloudSqlHook  # noqa
+from airflow.gcp.hooks.cloud_sql import CloudSQLDatabaseHook, CloudSQLHook
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.cloud_sql`",
-    DeprecationWarning, stacklevel=2
+    DeprecationWarning,
+    stacklevel=2,
 )
+
+
+class CloudSqlDatabaseHook(CloudSQLDatabaseHook):
+    """
+    This class is deprecated. Please use `airflow.gcp.hooks.sql.CloudSQLDatabaseHook`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=2)
+        super().__init__(*args, **kwargs)
+
+
+class CloudSqlHook(CloudSQLHook):
+    """
+    This class is deprecated. Please use `airflow.gcp.hooks.sql.CloudSQLHook`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=2)
+        super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcp_sql_operator.py
+++ b/airflow/contrib/operators/gcp_sql_operator.py
@@ -22,15 +22,114 @@ This module is deprecated. Please use `airflow.gcp.operators.cloud_sql`.
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.gcp.operators.cloud_sql import (  # noqa
-    CloudSqlBaseOperator, CloudSqlInstanceCreateOperator, CloudSqlInstanceDatabaseCreateOperator,
-    CloudSqlInstanceDatabaseDeleteOperator, CloudSqlInstanceDatabasePatchOperator,
-    CloudSqlInstanceDeleteOperator, CloudSqlInstanceExportOperator, CloudSqlInstanceImportOperator,
-    CloudSqlInstancePatchOperator, CloudSqlQueryOperator,
+from airflow.gcp.operators.cloud_sql import (
+    CloudSQLBaseOperator, CloudSQLCreateInstanceDatabaseOperator, CloudSQLCreateInstanceOperator,
+    CloudSQLDeleteInstanceDatabaseOperator, CloudSQLDeleteInstanceOperator, CloudSQLExecuteQueryOperator,
+    CloudSQLExportInstanceOperator, CloudSQLImportInstanceOperator, CloudSQLInstancePatchOperator,
+    CloudSQLPatchInstanceDatabaseOperator,
 )
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.cloud_sql`",
     DeprecationWarning, stacklevel=2
 )
+
+
+class CloudSqlBaseOperator(CloudSQLBaseOperator):
+    """
+    This class is deprecated. Please use `airflow.gcp.operators.sql.CloudSQLBaseOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=2)
+        super().__init__(*args, **kwargs)
+
+
+class CloudSqlInstanceCreateOperator(CloudSQLCreateInstanceOperator):
+    """
+    This class is deprecated. Please use `airflow.gcp.operators.sql.CloudSQLCreateInstanceOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=2)
+        super().__init__(*args, **kwargs)
+
+
+class CloudSqlInstanceDatabaseCreateOperator(CloudSQLCreateInstanceDatabaseOperator):
+    """
+    This class is deprecated. Please use `airflow.gcp.operators.sql.CloudSQLCreateInstanceDatabaseOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=2)
+        super().__init__(*args, **kwargs)
+
+
+class CloudSqlInstanceDatabaseDeleteOperator(CloudSQLDeleteInstanceDatabaseOperator):
+    """
+    This class is deprecated. Please use `airflow.gcp.operators.sql.CloudSQLDeleteInstanceDatabaseOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=2)
+        super().__init__(*args, **kwargs)
+
+
+class CloudSqlInstanceDatabasePatchOperator(CloudSQLPatchInstanceDatabaseOperator):
+    """
+    This class is deprecated. Please use `airflow.gcp.operators.sql.CloudSQLPatchInstanceDatabaseOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=2)
+        super().__init__(*args, **kwargs)
+
+
+class CloudSqlInstanceDeleteOperator(CloudSQLDeleteInstanceOperator):
+    """
+    This class is deprecated. Please use `airflow.gcp.operators.sql.CloudSQLDeleteInstanceOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=2)
+        super().__init__(*args, **kwargs)
+
+
+class CloudSqlInstanceExportOperator(CloudSQLExportInstanceOperator):
+    """
+    This class is deprecated. Please use `airflow.gcp.operators.sql.CloudSQLExportInstanceOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=2)
+        super().__init__(*args, **kwargs)
+
+
+class CloudSqlInstanceImportOperator(CloudSQLImportInstanceOperator):
+    """
+    This class is deprecated. Please use `airflow.gcp.operators.sql.CloudSQLImportInstanceOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=2)
+        super().__init__(*args, **kwargs)
+
+
+class CloudSqlInstancePatchOperator(CloudSQLInstancePatchOperator):
+    """
+    This class is deprecated. Please use `airflow.gcp.operators.sql.CloudSQLInstancePatchOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=2)
+        super().__init__(*args, **kwargs)
+
+
+class CloudSqlQueryOperator(CloudSQLExecuteQueryOperator):
+    """
+    This class is deprecated. Please use `airflow.gcp.operators.sql.CloudSQLExecuteQueryOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=2)
+        super().__init__(*args, **kwargs)

--- a/airflow/gcp/example_dags/example_cloud_sql.py
+++ b/airflow/gcp/example_dags/example_cloud_sql.py
@@ -34,10 +34,9 @@ from urllib.parse import urlsplit
 import airflow
 from airflow import models
 from airflow.gcp.operators.cloud_sql import (
-    CloudSqlInstanceCreateOperator, CloudSqlInstanceDatabaseCreateOperator,
-    CloudSqlInstanceDatabaseDeleteOperator, CloudSqlInstanceDatabasePatchOperator,
-    CloudSqlInstanceDeleteOperator, CloudSqlInstanceExportOperator, CloudSqlInstanceImportOperator,
-    CloudSqlInstancePatchOperator,
+    CloudSQLCreateInstanceDatabaseOperator, CloudSQLCreateInstanceOperator,
+    CloudSQLDeleteInstanceDatabaseOperator, CloudSQLDeleteInstanceOperator, CloudSQLExportInstanceOperator,
+    CloudSQLImportInstanceOperator, CloudSQLInstancePatchOperator, CloudSQLPatchInstanceDatabaseOperator,
 )
 from airflow.gcp.operators.gcs import (
     GoogleCloudStorageBucketCreateAclEntryOperator, GoogleCloudStorageObjectCreateAclEntryOperator,
@@ -190,7 +189,7 @@ with models.DAG(
     # ############################################## #
 
     # [START howto_operator_cloudsql_create]
-    sql_instance_create_task = CloudSqlInstanceCreateOperator(
+    sql_instance_create_task = CloudSQLCreateInstanceOperator(
         project_id=GCP_PROJECT_ID,
         body=body,
         instance=INSTANCE_NAME,
@@ -198,7 +197,7 @@ with models.DAG(
     )
     # [END howto_operator_cloudsql_create]
 
-    sql_instance_create_2_task = CloudSqlInstanceCreateOperator(
+    sql_instance_create_2_task = CloudSQLCreateInstanceOperator(
         project_id=GCP_PROJECT_ID,
         body=body2,
         instance=INSTANCE_NAME2,
@@ -206,7 +205,7 @@ with models.DAG(
     )
     # [END howto_operator_cloudsql_create]
 
-    sql_instance_read_replica_create = CloudSqlInstanceCreateOperator(
+    sql_instance_read_replica_create = CloudSQLCreateInstanceOperator(
         project_id=GCP_PROJECT_ID,
         body=read_replica_body,
         instance=INSTANCE_NAME2,
@@ -218,14 +217,14 @@ with models.DAG(
     # ############################################## #
 
     # [START howto_operator_cloudsql_patch]
-    sql_instance_patch_task = CloudSqlInstancePatchOperator(
+    sql_instance_patch_task = CloudSQLInstancePatchOperator(
         project_id=GCP_PROJECT_ID,
         body=patch_body,
         instance=INSTANCE_NAME,
         task_id='sql_instance_patch_task'
     )
 
-    sql_instance_patch_task2 = CloudSqlInstancePatchOperator(
+    sql_instance_patch_task2 = CloudSQLInstancePatchOperator(
         body=patch_body,
         instance=INSTANCE_NAME,
         task_id='sql_instance_patch_task2'
@@ -233,13 +232,13 @@ with models.DAG(
     # [END howto_operator_cloudsql_patch]
 
     # [START howto_operator_cloudsql_db_create]
-    sql_db_create_task = CloudSqlInstanceDatabaseCreateOperator(
+    sql_db_create_task = CloudSQLCreateInstanceDatabaseOperator(
         project_id=GCP_PROJECT_ID,
         body=db_create_body,
         instance=INSTANCE_NAME,
         task_id='sql_db_create_task'
     )
-    sql_db_create_task2 = CloudSqlInstanceDatabaseCreateOperator(
+    sql_db_create_task2 = CloudSQLCreateInstanceDatabaseOperator(
         body=db_create_body,
         instance=INSTANCE_NAME,
         task_id='sql_db_create_task2'
@@ -247,14 +246,14 @@ with models.DAG(
     # [END howto_operator_cloudsql_db_create]
 
     # [START howto_operator_cloudsql_db_patch]
-    sql_db_patch_task = CloudSqlInstanceDatabasePatchOperator(
+    sql_db_patch_task = CloudSQLPatchInstanceDatabaseOperator(
         project_id=GCP_PROJECT_ID,
         body=db_patch_body,
         instance=INSTANCE_NAME,
         database=DB_NAME,
         task_id='sql_db_patch_task'
     )
-    sql_db_patch_task2 = CloudSqlInstanceDatabasePatchOperator(
+    sql_db_patch_task2 = CloudSQLPatchInstanceDatabaseOperator(
         body=db_patch_body,
         instance=INSTANCE_NAME,
         database=DB_NAME,
@@ -281,13 +280,13 @@ with models.DAG(
     # [END howto_operator_cloudsql_export_gcs_permissions]
 
     # [START howto_operator_cloudsql_export]
-    sql_export_task = CloudSqlInstanceExportOperator(
+    sql_export_task = CloudSQLExportInstanceOperator(
         project_id=GCP_PROJECT_ID,
         body=export_body,
         instance=INSTANCE_NAME,
         task_id='sql_export_task'
     )
-    sql_export_task2 = CloudSqlInstanceExportOperator(
+    sql_export_task2 = CloudSQLExportInstanceOperator(
         body=export_body,
         instance=INSTANCE_NAME,
         task_id='sql_export_task2'
@@ -325,13 +324,13 @@ with models.DAG(
     # [END howto_operator_cloudsql_import_gcs_permissions]
 
     # [START howto_operator_cloudsql_import]
-    sql_import_task = CloudSqlInstanceImportOperator(
+    sql_import_task = CloudSQLImportInstanceOperator(
         project_id=GCP_PROJECT_ID,
         body=import_body,
         instance=INSTANCE_NAME2,
         task_id='sql_import_task'
     )
-    sql_import_task2 = CloudSqlInstanceImportOperator(
+    sql_import_task2 = CloudSQLImportInstanceOperator(
         body=import_body,
         instance=INSTANCE_NAME2,
         task_id='sql_import_task2'
@@ -343,13 +342,13 @@ with models.DAG(
     # ############################################## #
 
     # [START howto_operator_cloudsql_db_delete]
-    sql_db_delete_task = CloudSqlInstanceDatabaseDeleteOperator(
+    sql_db_delete_task = CloudSQLDeleteInstanceDatabaseOperator(
         project_id=GCP_PROJECT_ID,
         instance=INSTANCE_NAME,
         database=DB_NAME,
         task_id='sql_db_delete_task'
     )
-    sql_db_delete_task2 = CloudSqlInstanceDatabaseDeleteOperator(
+    sql_db_delete_task2 = CloudSQLDeleteInstanceDatabaseOperator(
         instance=INSTANCE_NAME,
         database=DB_NAME,
         task_id='sql_db_delete_task2'
@@ -361,13 +360,13 @@ with models.DAG(
     # ############################################## #
 
     # [START howto_operator_cloudsql_replicas_delete]
-    sql_instance_failover_replica_delete_task = CloudSqlInstanceDeleteOperator(
+    sql_instance_failover_replica_delete_task = CloudSQLDeleteInstanceOperator(
         project_id=GCP_PROJECT_ID,
         instance=FAILOVER_REPLICA_NAME,
         task_id='sql_instance_failover_replica_delete_task'
     )
 
-    sql_instance_read_replica_delete_task = CloudSqlInstanceDeleteOperator(
+    sql_instance_read_replica_delete_task = CloudSQLDeleteInstanceOperator(
         project_id=GCP_PROJECT_ID,
         instance=READ_REPLICA_NAME,
         task_id='sql_instance_read_replica_delete_task'
@@ -375,18 +374,18 @@ with models.DAG(
     # [END howto_operator_cloudsql_replicas_delete]
 
     # [START howto_operator_cloudsql_delete]
-    sql_instance_delete_task = CloudSqlInstanceDeleteOperator(
+    sql_instance_delete_task = CloudSQLDeleteInstanceOperator(
         project_id=GCP_PROJECT_ID,
         instance=INSTANCE_NAME,
         task_id='sql_instance_delete_task'
     )
-    sql_instance_delete_task2 = CloudSqlInstanceDeleteOperator(
+    sql_instance_delete_task2 = CloudSQLDeleteInstanceOperator(
         instance=INSTANCE_NAME2,
         task_id='sql_instance_delete_task2'
     )
     # [END howto_operator_cloudsql_delete]
 
-    sql_instance_delete_2_task = CloudSqlInstanceDeleteOperator(
+    sql_instance_delete_2_task = CloudSQLDeleteInstanceOperator(
         project_id=GCP_PROJECT_ID,
         instance=INSTANCE_NAME2,
         task_id='sql_instance_delete_2_task'

--- a/airflow/gcp/example_dags/example_cloud_sql_query.py
+++ b/airflow/gcp/example_dags/example_cloud_sql_query.py
@@ -44,7 +44,7 @@ from urllib.parse import quote_plus
 
 import airflow
 from airflow import models
-from airflow.gcp.operators.cloud_sql import CloudSqlQueryOperator
+from airflow.gcp.operators.cloud_sql import CloudSQLExecuteQueryOperator
 
 # [START howto_operator_cloudsql_query_arguments]
 
@@ -282,7 +282,7 @@ with models.DAG(
     prev_task = None
 
     for connection_name in connection_names:
-        task = CloudSqlQueryOperator(
+        task = CloudSQLExecuteQueryOperator(
             gcp_cloudsql_conn_id=connection_name,
             task_id="example_gcp_sql_task_" + connection_name,
             sql=SQL

--- a/airflow/gcp/hooks/cloud_sql.py
+++ b/airflow/gcp/hooks/cloud_sql.py
@@ -70,7 +70,7 @@ class CloudSqlOperationStatus:
 
 
 # noinspection PyAbstractClass
-class CloudSqlHook(CloudBaseHook):
+class CloudSQLHook(CloudBaseHook):
     """
     Hook for Google Cloud SQL APIs.
 
@@ -699,7 +699,7 @@ CLOUD_SQL_VALID_DATABASE_TYPES = ['postgres', 'mysql']
 
 
 # noinspection PyAbstractClass
-class CloudSqlDatabaseHook(BaseHook):
+class CloudSQLDatabaseHook(BaseHook):
     # pylint: disable=too-many-instance-attributes
     """
     Serves DB connection configuration for Google Cloud SQL (Connections

--- a/airflow/gcp/operators/cloud_sql.py
+++ b/airflow/gcp/operators/cloud_sql.py
@@ -24,7 +24,7 @@ from typing import Dict, Iterable, List, Optional, Union
 from googleapiclient.errors import HttpError
 
 from airflow import AirflowException
-from airflow.gcp.hooks.cloud_sql import CloudSqlDatabaseHook, CloudSqlHook
+from airflow.gcp.hooks.cloud_sql import CloudSQLDatabaseHook, CloudSQLHook
 from airflow.gcp.utils.field_validator import GcpBodyFieldValidator
 from airflow.hooks.base_hook import BaseHook
 from airflow.hooks.mysql_hook import MySqlHook
@@ -140,7 +140,7 @@ CLOUD_SQL_DATABASE_PATCH_VALIDATION = [
 ]
 
 
-class CloudSqlBaseOperator(BaseOperator):
+class CloudSQLBaseOperator(BaseOperator):
     """
     Abstract base operator for Google Cloud SQL operators to inherit from.
 
@@ -174,7 +174,7 @@ class CloudSqlBaseOperator(BaseOperator):
         if not self.instance:
             raise AirflowException("The required parameter 'instance' is empty or None")
 
-    def _check_if_instance_exists(self, instance, hook: CloudSqlHook):
+    def _check_if_instance_exists(self, instance, hook: CloudSQLHook):
         try:
             return hook.get_instance(
                 project_id=self.project_id,
@@ -186,7 +186,7 @@ class CloudSqlBaseOperator(BaseOperator):
                 return False
             raise e
 
-    def _check_if_db_exists(self, db_name, hook: CloudSqlHook):
+    def _check_if_db_exists(self, db_name, hook: CloudSQLHook):
         try:
             return hook.get_database(
                 project_id=self.project_id,
@@ -206,7 +206,7 @@ class CloudSqlBaseOperator(BaseOperator):
         return instance.get(SETTINGS).get(SETTINGS_VERSION)
 
 
-class CloudSqlInstanceCreateOperator(CloudSqlBaseOperator):
+class CloudSQLCreateInstanceOperator(CloudSQLBaseOperator):
     """
     Creates a new Cloud SQL instance.
     If an instance with the same name exists, no action will be taken and
@@ -262,7 +262,7 @@ class CloudSqlInstanceCreateOperator(CloudSqlBaseOperator):
                                   api_version=self.api_version).validate(self.body)
 
     def execute(self, context):
-        hook = CloudSqlHook(
+        hook = CloudSQLHook(
             gcp_conn_id=self.gcp_conn_id,
             api_version=self.api_version
         )
@@ -285,7 +285,7 @@ class CloudSqlInstanceCreateOperator(CloudSqlBaseOperator):
         task_instance.xcom_push(key="service_account_email", value=service_account_email)
 
 
-class CloudSqlInstancePatchOperator(CloudSqlBaseOperator):
+class CloudSQLInstancePatchOperator(CloudSQLBaseOperator):
     """
     Updates settings of a Cloud SQL instance.
 
@@ -336,7 +336,7 @@ class CloudSqlInstancePatchOperator(CloudSqlBaseOperator):
             raise AirflowException("The required parameter 'body' is empty")
 
     def execute(self, context):
-        hook = CloudSqlHook(
+        hook = CloudSQLHook(
             gcp_conn_id=self.gcp_conn_id,
             api_version=self.api_version
         )
@@ -351,7 +351,7 @@ class CloudSqlInstancePatchOperator(CloudSqlBaseOperator):
                 instance=self.instance)
 
 
-class CloudSqlInstanceDeleteOperator(CloudSqlBaseOperator):
+class CloudSQLDeleteInstanceOperator(CloudSQLBaseOperator):
     """
     Deletes a Cloud SQL instance.
 
@@ -385,7 +385,7 @@ class CloudSqlInstanceDeleteOperator(CloudSqlBaseOperator):
             api_version=api_version, *args, **kwargs)
 
     def execute(self, context):
-        hook = CloudSqlHook(
+        hook = CloudSQLHook(
             gcp_conn_id=self.gcp_conn_id,
             api_version=self.api_version
         )
@@ -399,7 +399,7 @@ class CloudSqlInstanceDeleteOperator(CloudSqlBaseOperator):
                 instance=self.instance)
 
 
-class CloudSqlInstanceDatabaseCreateOperator(CloudSqlBaseOperator):
+class CloudSQLCreateInstanceDatabaseOperator(CloudSQLBaseOperator):
     """
     Creates a new database inside a Cloud SQL instance.
 
@@ -458,7 +458,7 @@ class CloudSqlInstanceDatabaseCreateOperator(CloudSqlBaseOperator):
             self.log.error("Body doesn't contain 'name'. Cannot check if the"
                            " database already exists in the instance %s.", self.instance)
             return False
-        hook = CloudSqlHook(
+        hook = CloudSQLHook(
             gcp_conn_id=self.gcp_conn_id,
             api_version=self.api_version
         )
@@ -474,7 +474,7 @@ class CloudSqlInstanceDatabaseCreateOperator(CloudSqlBaseOperator):
             )
 
 
-class CloudSqlInstanceDatabasePatchOperator(CloudSqlBaseOperator):
+class CloudSQLPatchInstanceDatabaseOperator(CloudSQLBaseOperator):
     """
     Updates a resource containing information about a database inside a Cloud SQL
     instance using patch semantics.
@@ -536,7 +536,7 @@ class CloudSqlInstanceDatabasePatchOperator(CloudSqlBaseOperator):
 
     def execute(self, context):
         self._validate_body_fields()
-        hook = CloudSqlHook(
+        hook = CloudSQLHook(
             gcp_conn_id=self.gcp_conn_id,
             api_version=self.api_version
         )
@@ -553,7 +553,7 @@ class CloudSqlInstanceDatabasePatchOperator(CloudSqlBaseOperator):
                 body=self.body)
 
 
-class CloudSqlInstanceDatabaseDeleteOperator(CloudSqlBaseOperator):
+class CloudSQLDeleteInstanceDatabaseOperator(CloudSQLBaseOperator):
     """
     Deletes a database from a Cloud SQL instance.
 
@@ -597,7 +597,7 @@ class CloudSqlInstanceDatabaseDeleteOperator(CloudSqlBaseOperator):
             raise AirflowException("The required parameter 'database' is empty")
 
     def execute(self, context):
-        hook = CloudSqlHook(
+        hook = CloudSQLHook(
             gcp_conn_id=self.gcp_conn_id,
             api_version=self.api_version
         )
@@ -613,7 +613,7 @@ class CloudSqlInstanceDatabaseDeleteOperator(CloudSqlBaseOperator):
                 database=self.database)
 
 
-class CloudSqlInstanceExportOperator(CloudSqlBaseOperator):
+class CloudSQLExportInstanceOperator(CloudSQLBaseOperator):
     """
     Exports data from a Cloud SQL instance to a Cloud Storage bucket as a SQL dump
     or CSV file.
@@ -671,7 +671,7 @@ class CloudSqlInstanceExportOperator(CloudSqlBaseOperator):
 
     def execute(self, context):
         self._validate_body_fields()
-        hook = CloudSqlHook(
+        hook = CloudSQLHook(
             gcp_conn_id=self.gcp_conn_id,
             api_version=self.api_version
         )
@@ -681,7 +681,7 @@ class CloudSqlInstanceExportOperator(CloudSqlBaseOperator):
             body=self.body)
 
 
-class CloudSqlInstanceImportOperator(CloudSqlBaseOperator):
+class CloudSQLImportInstanceOperator(CloudSQLBaseOperator):
     """
     Imports data into a Cloud SQL instance from a SQL dump or CSV file in Cloud Storage.
 
@@ -751,7 +751,7 @@ class CloudSqlInstanceImportOperator(CloudSqlBaseOperator):
 
     def execute(self, context):
         self._validate_body_fields()
-        hook = CloudSqlHook(
+        hook = CloudSQLHook(
             gcp_conn_id=self.gcp_conn_id,
             api_version=self.api_version
         )
@@ -761,7 +761,7 @@ class CloudSqlInstanceImportOperator(CloudSqlBaseOperator):
             body=self.body)
 
 
-class CloudSqlQueryOperator(BaseOperator):
+class CloudSQLExecuteQueryOperator(BaseOperator):
     """
     Performs DML or DDL query on an existing Cloud Sql instance. It optionally uses
     cloud-sql-proxy to establish secure connection with the database.
@@ -811,7 +811,7 @@ class CloudSqlQueryOperator(BaseOperator):
         self.parameters = parameters
         self.gcp_connection = BaseHook.get_connection(self.gcp_conn_id)
 
-    def _execute_query(self, hook: CloudSqlDatabaseHook, database_hook: Union[PostgresHook, MySqlHook]):
+    def _execute_query(self, hook: CloudSQLDatabaseHook, database_hook: Union[PostgresHook, MySqlHook]):
         cloud_sql_proxy_runner = None
         try:
             if hook.use_proxy:
@@ -828,7 +828,7 @@ class CloudSqlQueryOperator(BaseOperator):
                 cloud_sql_proxy_runner.stop_proxy()
 
     def execute(self, context):
-        hook = CloudSqlDatabaseHook(
+        hook = CloudSQLDatabaseHook(
             gcp_cloudsql_conn_id=self.gcp_cloudsql_conn_id,
             gcp_conn_id=self.gcp_conn_id,
             default_gcp_project_id=self.gcp_connection.extra_dejson.get(

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -299,8 +299,8 @@ class Connection(Base, LoggingMixin):
             from airflow.contrib.hooks.mongo_hook import MongoHook
             return MongoHook(conn_id=self.conn_id)
         elif self.conn_type == 'gcpcloudsql':
-            from airflow.gcp.hooks.cloud_sql import CloudSqlDatabaseHook
-            return CloudSqlDatabaseHook(gcp_cloudsql_conn_id=self.conn_id)
+            from airflow.gcp.hooks.cloud_sql import CloudSQLDatabaseHook
+            return CloudSQLDatabaseHook(gcp_cloudsql_conn_id=self.conn_id)
         elif self.conn_type == 'grpc':
             from airflow.contrib.hooks.grpc_hook import GrpcHook
             return GrpcHook(grpc_conn_id=self.conn_id)

--- a/tests/gcp/hooks/test_cloud_sql.py
+++ b/tests/gcp/hooks/test_cloud_sql.py
@@ -28,7 +28,7 @@ from mock import PropertyMock
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
-from airflow.gcp.hooks.cloud_sql import CloudSqlDatabaseHook, CloudSqlHook
+from airflow.gcp.hooks.cloud_sql import CloudSQLDatabaseHook, CloudSQLHook
 from airflow.models import Connection
 from tests.gcp.utils.base_gcp_mock import (
     mock_base_gcp_hook_default_project_id, mock_base_gcp_hook_no_default_project_id,
@@ -40,9 +40,9 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
     def setUp(self):
         with mock.patch('airflow.gcp.hooks.base.CloudBaseHook.__init__',
                         new=mock_base_gcp_hook_default_project_id):
-            self.cloudsql_hook = CloudSqlHook(api_version='v1', gcp_conn_id='test')
+            self.cloudsql_hook = CloudSQLHook(api_version='v1', gcp_conn_id='test')
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._get_credentials_and_project_id',
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._get_credentials_and_project_id',
                 return_value=(mock.MagicMock(), 'example-project'))
     def test_instance_import_exception(self, mock_get_credentials):
         self.cloudsql_hook.get_conn = mock.Mock(
@@ -56,7 +56,7 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
         err = cm.exception
         self.assertIn("Importing instance ", str(err))
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._get_credentials_and_project_id',
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._get_credentials_and_project_id',
                 return_value=(mock.MagicMock(), 'example-project'))
     def test_instance_export_exception(self, mock_get_credentials):
         self.cloudsql_hook.get_conn = mock.Mock(
@@ -70,10 +70,10 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
         err = cm.exception
         self.assertIn("Exporting instance ", str(err))
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._get_credentials_and_project_id',
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._get_credentials_and_project_id',
                 return_value=(mock.MagicMock(), 'example-project'))
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_instance_import(self, wait_for_operation_to_complete, get_conn, mock_get_credentials):
         import_method = get_conn.return_value.instances.return_value.import_
         execute_method = import_method.return_value.execute
@@ -88,8 +88,8 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
         wait_for_operation_to_complete.assert_called_once_with(project_id='example-project',
                                                                operation_name='operation_id')
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_instance_import_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
         import_method = get_conn.return_value.instances.return_value.import_
         execute_method = import_method.return_value.execute
@@ -105,10 +105,10 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
         wait_for_operation_to_complete.assert_called_once_with(project_id='new-project',
                                                                operation_name='operation_id')
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._get_credentials_and_project_id',
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._get_credentials_and_project_id',
                 return_value=(mock.MagicMock(), 'example-project'))
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_instance_export(self, wait_for_operation_to_complete, get_conn, mock_get_credentials):
         export_method = get_conn.return_value.instances.return_value.export
         execute_method = export_method.return_value.execute
@@ -123,8 +123,8 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
         wait_for_operation_to_complete.assert_called_once_with(project_id='example-project',
                                                                operation_name='operation_id')
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_instance_export_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
         export_method = get_conn.return_value.instances.return_value.export
         execute_method = export_method.return_value.execute
@@ -140,10 +140,10 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
         wait_for_operation_to_complete.assert_called_once_with(project_id='new-project',
                                                                operation_name='operation_id')
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._get_credentials_and_project_id',
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._get_credentials_and_project_id',
                 return_value=(mock.MagicMock(), 'example-project'))
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_get_instance(self, wait_for_operation_to_complete, get_conn, mock_get_credentials):
         get_method = get_conn.return_value.instances.return_value.get
         execute_method = get_method.return_value.execute
@@ -157,8 +157,8 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
         wait_for_operation_to_complete.assert_not_called()
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_get_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
         get_method = get_conn.return_value.instances.return_value.get
         execute_method = get_method.return_value.execute
@@ -173,10 +173,10 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
         wait_for_operation_to_complete.assert_not_called()
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._get_credentials_and_project_id',
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._get_credentials_and_project_id',
                 return_value=(mock.MagicMock(), 'example-project'))
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_create_instance(self, wait_for_operation_to_complete, get_conn, mock_get_credentials):
         insert_method = get_conn.return_value.instances.return_value.insert
         execute_method = insert_method.return_value.execute
@@ -191,8 +191,8 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
             operation_name='operation_id', project_id='example-project'
         )
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_create_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
         insert_method = get_conn.return_value.instances.return_value.insert
         execute_method = insert_method.return_value.execute
@@ -208,10 +208,10 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
             operation_name='operation_id', project_id='new-project'
         )
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._get_credentials_and_project_id',
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._get_credentials_and_project_id',
                 return_value=(mock.MagicMock(), 'example-project'))
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_patch_instance(self, wait_for_operation_to_complete, get_conn, mock_get_credentials):
         patch_method = get_conn.return_value.instances.return_value.patch
         execute_method = patch_method.return_value.execute
@@ -227,8 +227,8 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
             operation_name='operation_id', project_id='example-project'
         )
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_patch_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
         patch_method = get_conn.return_value.instances.return_value.patch
         execute_method = patch_method.return_value.execute
@@ -245,10 +245,10 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
             operation_name='operation_id', project_id='new-project'
         )
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._get_credentials_and_project_id',
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._get_credentials_and_project_id',
                 return_value=(mock.MagicMock(), 'example-project'))
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_delete_instance(self, wait_for_operation_to_complete, get_conn, mock_get_credentials):
         delete_method = get_conn.return_value.instances.return_value.delete
         execute_method = delete_method.return_value.execute
@@ -263,8 +263,8 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
             operation_name='operation_id', project_id='example-project'
         )
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_delete_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
         delete_method = get_conn.return_value.instances.return_value.delete
         execute_method = delete_method.return_value.execute
@@ -280,10 +280,10 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
             operation_name='operation_id', project_id='new-project'
         )
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._get_credentials_and_project_id',
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._get_credentials_and_project_id',
                 return_value=(mock.MagicMock(), 'example-project'))
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_get_database(self, wait_for_operation_to_complete, get_conn, mock_get_credentials):
         get_method = get_conn.return_value.databases.return_value.get
         execute_method = get_method.return_value.execute
@@ -300,8 +300,8 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
         wait_for_operation_to_complete.assert_not_called()
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_get_database_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
         get_method = get_conn.return_value.databases.return_value.get
         execute_method = get_method.return_value.execute
@@ -319,10 +319,10 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
         wait_for_operation_to_complete.assert_not_called()
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._get_credentials_and_project_id',
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._get_credentials_and_project_id',
                 return_value=(mock.MagicMock(), 'example-project'))
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_create_database(self, wait_for_operation_to_complete, get_conn, mock_get_credentials):
         insert_method = get_conn.return_value.databases.return_value.insert
         execute_method = insert_method.return_value.execute
@@ -338,8 +338,8 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
             operation_name='operation_id', project_id='example-project'
         )
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_create_database_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
         insert_method = get_conn.return_value.databases.return_value.insert
         execute_method = insert_method.return_value.execute
@@ -356,10 +356,10 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
             operation_name='operation_id', project_id='new-project'
         )
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._get_credentials_and_project_id',
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._get_credentials_and_project_id',
                 return_value=(mock.MagicMock(), 'example-project'))
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_patch_database(self, wait_for_operation_to_complete, get_conn, mock_get_credentials):
         patch_method = get_conn.return_value.databases.return_value.patch
         execute_method = patch_method.return_value.execute
@@ -379,8 +379,8 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
             operation_name='operation_id', project_id='example-project'
         )
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_patch_database_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
         patch_method = get_conn.return_value.databases.return_value.patch
         execute_method = patch_method.return_value.execute
@@ -401,10 +401,10 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
             operation_name='operation_id', project_id='new-project'
         )
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._get_credentials_and_project_id',
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._get_credentials_and_project_id',
                 return_value=(mock.MagicMock(), 'example-project'))
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_delete_database(self, wait_for_operation_to_complete, get_conn, mock_get_credentials):
         delete_method = get_conn.return_value.databases.return_value.delete
         execute_method = delete_method.return_value.execute
@@ -422,8 +422,8 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
             operation_name='operation_id', project_id='example-project'
         )
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_delete_database_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
         delete_method = get_conn.return_value.databases.return_value.delete
         execute_method = delete_method.return_value.execute
@@ -447,15 +447,15 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
     def setUp(self):
         with mock.patch('airflow.gcp.hooks.base.CloudBaseHook.__init__',
                         new=mock_base_gcp_hook_no_default_project_id):
-            self.cloudsql_hook_no_default_project_id = CloudSqlHook(api_version='v1', gcp_conn_id='test')
+            self.cloudsql_hook_no_default_project_id = CloudSQLHook(api_version='v1', gcp_conn_id='test')
 
     @mock.patch(
         'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_instance_import_overridden_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -478,8 +478,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_instance_import_missing_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -502,8 +502,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_instance_export_overridden_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -526,8 +526,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_instance_export_missing_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -550,8 +550,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_get_instance_overridden_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -573,8 +573,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_get_instance_missing_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -596,8 +596,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_create_instance_overridden_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -620,8 +620,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_create_instance_missing_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -643,8 +643,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_patch_instance_overridden_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -668,8 +668,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_patch_instance_missing_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -692,8 +692,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_delete_instance_overridden_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -716,8 +716,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_delete_instance_missing_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -739,8 +739,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_get_database_overridden_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -765,8 +765,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_get_database_missing_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -789,8 +789,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_create_database_overridden_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -814,8 +814,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_create_database_missing_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -838,8 +838,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_patch_database_overridden_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -867,8 +867,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_patch_database_missing_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -892,8 +892,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_delete_database_overridden_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -919,8 +919,8 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLHook._wait_for_operation_to_complete')
     def test_delete_database_missing_project_id(
         self, wait_for_operation_to_complete, get_conn, mock_project_id
     ):
@@ -941,7 +941,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
 
 class TestCloudsqlDatabaseHook(unittest.TestCase):
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection')
     def test_cloudsql_database_hook_validate_ssl_certs_no_ssl(self, get_connection):
         connection = Connection()
         connection.set_extra(json.dumps({
@@ -950,7 +950,7 @@ class TestCloudsqlDatabaseHook(unittest.TestCase):
             "database_type": "postgres"
         }))
         get_connection.return_value = connection
-        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+        hook = CloudSQLDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
                                     default_gcp_project_id='google_connection')
         hook.validate_ssl_certs()
 
@@ -964,7 +964,7 @@ class TestCloudsqlDatabaseHook(unittest.TestCase):
         [{"sslrootcert": "root_cert_file.pem", "sslcert": "cert_file.pem"}],
     ])
     @mock.patch('os.path.isfile')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection')
     def test_cloudsql_database_hook_validate_ssl_certs_missing_cert_params(
             self, cert_dict, get_connection, mock_is_file):
         mock_is_file.side_effects = True
@@ -979,7 +979,7 @@ class TestCloudsqlDatabaseHook(unittest.TestCase):
         connection.set_extra(json.dumps(extras))
 
         get_connection.return_value = connection
-        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+        hook = CloudSQLDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
                                     default_gcp_project_id='google_connection')
         with self.assertRaises(AirflowException) as cm:
             hook.validate_ssl_certs()
@@ -987,7 +987,7 @@ class TestCloudsqlDatabaseHook(unittest.TestCase):
         self.assertIn("SSL connections requires", str(err))
 
     @mock.patch('os.path.isfile')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection')
     def test_cloudsql_database_hook_validate_ssl_certs_with_ssl(self, get_connection, mock_is_file):
         connection = Connection()
         mock_is_file.return_value = True
@@ -1001,12 +1001,12 @@ class TestCloudsqlDatabaseHook(unittest.TestCase):
             "sslkey": "key_file.pem",
         }))
         get_connection.return_value = connection
-        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+        hook = CloudSQLDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
                                     default_gcp_project_id='google_connection')
         hook.validate_ssl_certs()
 
     @mock.patch('os.path.isfile')
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection')
     def test_cloudsql_database_hook_validate_ssl_certs_with_ssl_files_not_readable(
             self, get_connection, mock_is_file):
         connection = Connection()
@@ -1021,14 +1021,14 @@ class TestCloudsqlDatabaseHook(unittest.TestCase):
             "sslkey": "key_file.pem",
         }))
         get_connection.return_value = connection
-        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+        hook = CloudSQLDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
                                     default_gcp_project_id='google_connection')
         with self.assertRaises(AirflowException) as cm:
             hook.validate_ssl_certs()
         err = cm.exception
         self.assertIn("must be a readable file", str(err))
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection')
     def test_cloudsql_database_hook_validate_socket_path_length_too_long(self, get_connection):
         connection = Connection()
         connection.set_extra(json.dumps({
@@ -1039,14 +1039,14 @@ class TestCloudsqlDatabaseHook(unittest.TestCase):
             "use_tcp": "False"
         }))
         get_connection.return_value = connection
-        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+        hook = CloudSQLDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
                                     default_gcp_project_id='google_connection')
         with self.assertRaises(AirflowException) as cm:
             hook.validate_socket_path_length()
         err = cm.exception
         self.assertIn("The UNIX socket path length cannot exceed", str(err))
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection')
     def test_cloudsql_database_hook_validate_socket_path_length_not_too_long(self, get_connection):
         connection = Connection()
         connection.set_extra(json.dumps({
@@ -1057,7 +1057,7 @@ class TestCloudsqlDatabaseHook(unittest.TestCase):
             "use_tcp": "False"
         }))
         get_connection.return_value = connection
-        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+        hook = CloudSQLDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
                                     default_gcp_project_id='google_connection')
         hook.validate_socket_path_length()
 
@@ -1070,7 +1070,7 @@ class TestCloudsqlDatabaseHook(unittest.TestCase):
         ["http://host:80/database"],
         ["http://host:80/"],
     ])
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection')
     def test_cloudsql_database_hook_create_connection_missing_fields(self, uri, get_connection):
         connection = Connection()
         connection.parse_from_uri(uri)
@@ -1083,14 +1083,14 @@ class TestCloudsqlDatabaseHook(unittest.TestCase):
         }
         connection.set_extra(json.dumps(params))
         get_connection.return_value = connection
-        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+        hook = CloudSQLDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
                                     default_gcp_project_id='google_connection')
         with self.assertRaises(AirflowException) as cm:
             hook.create_connection()
         err = cm.exception
         self.assertIn("needs to be set in connection", str(err))
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection')
     def test_cloudsql_database_hook_get_sqlproxy_runner_no_proxy(self, get_connection):
         connection = Connection()
         connection.parse_from_uri("http://user:password@host:80/database")
@@ -1100,14 +1100,14 @@ class TestCloudsqlDatabaseHook(unittest.TestCase):
             "database_type": "postgres",
         }))
         get_connection.return_value = connection
-        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+        hook = CloudSQLDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
                                     default_gcp_project_id='google_connection')
         with self.assertRaises(ValueError) as cm:
             hook.get_sqlproxy_runner()
         err = cm.exception
         self.assertIn('Proxy runner can only be retrieved in case of use_proxy = True', str(err))
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection')
     def test_cloudsql_database_hook_get_sqlproxy_runner(self, get_connection):
         connection = Connection()
         connection.parse_from_uri("http://user:password@host:80/database")
@@ -1119,13 +1119,13 @@ class TestCloudsqlDatabaseHook(unittest.TestCase):
             'use_tcp': "False"
         }))
         get_connection.return_value = connection
-        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+        hook = CloudSQLDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
                                     default_gcp_project_id='google_connection')
         hook.create_connection()
         proxy_runner = hook.get_sqlproxy_runner()
         self.assertIsNotNone(proxy_runner)
 
-    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection')
+    @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection')
     def test_cloudsql_database_hook_get_database_hook(self, get_connection):
         connection = Connection()
         connection.parse_from_uri("http://user:password@host:80/database")
@@ -1135,7 +1135,7 @@ class TestCloudsqlDatabaseHook(unittest.TestCase):
             "database_type": "postgres",
         }))
         get_connection.return_value = connection
-        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+        hook = CloudSQLDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
                                     default_gcp_project_id='google_connection')
         connection = hook.create_connection()
         db_hook = hook.get_database_hook(connection=connection)
@@ -1144,7 +1144,7 @@ class TestCloudsqlDatabaseHook(unittest.TestCase):
 
 class TestCloudSqlDatabaseHook(unittest.TestCase):
 
-    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlDatabaseHook.get_connection')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSQLDatabaseHook.get_connection')
     def setUp(self, m):
         super().setUp()
 
@@ -1181,7 +1181,7 @@ class TestCloudSqlDatabaseHook(unittest.TestCase):
         self.connection.set_extra(conn_extra_json)
 
         m.side_effect = [self.sql_connection, self.connection]
-        self.db_hook = CloudSqlDatabaseHook(
+        self.db_hook = CloudSQLDatabaseHook(
             gcp_cloudsql_conn_id='my_gcp_sql_connection',
             gcp_conn_id='my_gcp_connection'
         )
@@ -1198,7 +1198,7 @@ class TestCloudSqlDatabaseHook(unittest.TestCase):
         )
         self.assertEqual(sqlproxy_runner.instance_specification, instance_spec)
 
-    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection")
+    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection")
     def test_hook_with_not_too_long_unix_socket_path(self, get_connection):
         uri = "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=postgres&" \
               "project_id=example-project&location=europe-west1&" \
@@ -1206,32 +1206,32 @@ class TestCloudSqlDatabaseHook(unittest.TestCase):
               "test_db_with_longname_but_with_limit_of_UNIX_socket&" \
               "use_proxy=True&sql_proxy_use_tcp=False"
         get_connection.side_effect = [Connection(uri=uri)]
-        hook = CloudSqlDatabaseHook()
+        hook = CloudSQLDatabaseHook()
         connection = hook.create_connection()
         self.assertEqual('postgres', connection.conn_type)
         self.assertEqual('testdb', connection.schema)
 
-    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection")
+    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection")
     def test_hook_with_correct_parameters_postgres(self, get_connection):
         uri = "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=postgres&" \
               "project_id=example-project&location=europe-west1&instance=testdb&" \
               "use_proxy=False&use_ssl=False"
         get_connection.side_effect = [Connection(uri=uri)]
-        hook = CloudSqlDatabaseHook()
+        hook = CloudSQLDatabaseHook()
         connection = hook.create_connection()
         self.assertEqual('postgres', connection.conn_type)
         self.assertEqual('127.0.0.1', connection.host)
         self.assertEqual(3200, connection.port)
         self.assertEqual('testdb', connection.schema)
 
-    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection")
+    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection")
     def test_hook_with_correct_parameters_postgres_ssl(self, get_connection):
         uri = "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=postgres&" \
               "project_id=example-project&location=europe-west1&instance=testdb&" \
               "use_proxy=False&use_ssl=True&sslcert=/bin/bash&" \
               "sslkey=/bin/bash&sslrootcert=/bin/bash"
         get_connection.side_effect = [Connection(uri=uri)]
-        hook = CloudSqlDatabaseHook()
+        hook = CloudSQLDatabaseHook()
         connection = hook.create_connection()
         self.assertEqual('postgres', connection.conn_type)
         self.assertEqual('127.0.0.1', connection.host)
@@ -1241,13 +1241,13 @@ class TestCloudSqlDatabaseHook(unittest.TestCase):
         self.assertEqual('/bin/bash', connection.extra_dejson['sslcert'])
         self.assertEqual('/bin/bash', connection.extra_dejson['sslrootcert'])
 
-    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection")
+    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection")
     def test_hook_with_correct_parameters_postgres_proxy_socket(self, get_connection):
         uri = "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=postgres&" \
               "project_id=example-project&location=europe-west1&instance=testdb&" \
               "use_proxy=True&sql_proxy_use_tcp=False"
         get_connection.side_effect = [Connection(uri=uri)]
-        hook = CloudSqlDatabaseHook()
+        hook = CloudSQLDatabaseHook()
         connection = hook.create_connection()
         self.assertEqual('postgres', connection.conn_type)
         self.assertIn('/tmp', connection.host)
@@ -1255,53 +1255,53 @@ class TestCloudSqlDatabaseHook(unittest.TestCase):
         self.assertIsNone(connection.port)
         self.assertEqual('testdb', connection.schema)
 
-    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection")
+    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection")
     def test_hook_with_correct_parameters_project_id_missing(self, get_connection):
         uri = "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=mysql&" \
               "location=europe-west1&instance=testdb&" \
               "use_proxy=False&use_ssl=False"
         get_connection.side_effect = [Connection(uri=uri)]
-        hook = CloudSqlDatabaseHook()
+        hook = CloudSQLDatabaseHook()
         connection = hook.create_connection()
         self.assertEqual('mysql', connection.conn_type)
         self.assertEqual('127.0.0.1', connection.host)
         self.assertEqual(3200, connection.port)
         self.assertEqual('testdb', connection.schema)
 
-    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection")
+    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection")
     def test_hook_with_correct_parameters_postgres_proxy_tcp(self, get_connection):
         uri = "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=postgres&" \
               "project_id=example-project&location=europe-west1&instance=testdb&" \
               "use_proxy=True&sql_proxy_use_tcp=True"
         get_connection.side_effect = [Connection(uri=uri)]
-        hook = CloudSqlDatabaseHook()
+        hook = CloudSQLDatabaseHook()
         connection = hook.create_connection()
         self.assertEqual('postgres', connection.conn_type)
         self.assertEqual('127.0.0.1', connection.host)
         self.assertNotEqual(3200, connection.port)
         self.assertEqual('testdb', connection.schema)
 
-    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection")
+    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection")
     def test_hook_with_correct_parameters_mysql(self, get_connection):
         uri = "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=mysql&" \
               "project_id=example-project&location=europe-west1&instance=testdb&" \
               "use_proxy=False&use_ssl=False"
         get_connection.side_effect = [Connection(uri=uri)]
-        hook = CloudSqlDatabaseHook()
+        hook = CloudSQLDatabaseHook()
         connection = hook.create_connection()
         self.assertEqual('mysql', connection.conn_type)
         self.assertEqual('127.0.0.1', connection.host)
         self.assertEqual(3200, connection.port)
         self.assertEqual('testdb', connection.schema)
 
-    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection")
+    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection")
     def test_hook_with_correct_parameters_mysql_ssl(self, get_connection):
         uri = "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=mysql&" \
               "project_id=example-project&location=europe-west1&instance=testdb&" \
               "use_proxy=False&use_ssl=True&sslcert=/bin/bash&" \
               "sslkey=/bin/bash&sslrootcert=/bin/bash"
         get_connection.side_effect = [Connection(uri=uri)]
-        hook = CloudSqlDatabaseHook()
+        hook = CloudSQLDatabaseHook()
         connection = hook.create_connection()
         self.assertEqual('mysql', connection.conn_type)
         self.assertEqual('127.0.0.1', connection.host)
@@ -1311,13 +1311,13 @@ class TestCloudSqlDatabaseHook(unittest.TestCase):
         self.assertEqual('/bin/bash', json.loads(connection.extra_dejson['ssl'])['key'])
         self.assertEqual('/bin/bash', json.loads(connection.extra_dejson['ssl'])['ca'])
 
-    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection")
+    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection")
     def test_hook_with_correct_parameters_mysql_proxy_socket(self, get_connection):
         uri = "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=mysql&" \
               "project_id=example-project&location=europe-west1&instance=testdb&" \
               "use_proxy=True&sql_proxy_use_tcp=False"
         get_connection.side_effect = [Connection(uri=uri)]
-        hook = CloudSqlDatabaseHook()
+        hook = CloudSQLDatabaseHook()
         connection = hook.create_connection()
         self.assertEqual('mysql', connection.conn_type)
         self.assertEqual('localhost', connection.host)
@@ -1327,13 +1327,13 @@ class TestCloudSqlDatabaseHook(unittest.TestCase):
         self.assertIsNone(connection.port)
         self.assertEqual('testdb', connection.schema)
 
-    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook.get_connection")
+    @mock.patch("airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection")
     def test_hook_with_correct_parameters_mysql_tcp(self, get_connection):
         uri = "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=mysql&" \
               "project_id=example-project&location=europe-west1&instance=testdb&" \
               "use_proxy=True&sql_proxy_use_tcp=True"
         get_connection.side_effect = [Connection(uri=uri)]
-        hook = CloudSqlDatabaseHook()
+        hook = CloudSQLDatabaseHook()
         connection = hook.create_connection()
         self.assertEqual('mysql', connection.conn_type)
         self.assertEqual('127.0.0.1', connection.host)

--- a/tests/gcp/operators/test_cloud_sql.py
+++ b/tests/gcp/operators/test_cloud_sql.py
@@ -27,10 +27,10 @@ from parameterized import parameterized
 
 from airflow import AirflowException
 from airflow.gcp.operators.cloud_sql import (
-    CloudSqlInstanceCreateOperator, CloudSqlInstanceDatabaseCreateOperator,
-    CloudSqlInstanceDatabaseDeleteOperator, CloudSqlInstanceDatabasePatchOperator,
-    CloudSqlInstanceDeleteOperator, CloudSqlInstanceExportOperator, CloudSqlInstanceImportOperator,
-    CloudSqlInstancePatchOperator, CloudSqlQueryOperator,
+    CloudSQLCreateInstanceDatabaseOperator, CloudSQLCreateInstanceOperator,
+    CloudSQLDeleteInstanceDatabaseOperator, CloudSQLDeleteInstanceOperator, CloudSQLExecuteQueryOperator,
+    CloudSQLExportInstanceOperator, CloudSQLImportInstanceOperator, CloudSQLInstancePatchOperator,
+    CloudSQLPatchInstanceDatabaseOperator,
 )
 from airflow.models import Connection
 
@@ -161,12 +161,12 @@ IMPORT_BODY = {
 
 
 class TestCloudSql(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlInstanceCreateOperator._check_if_instance_exists")
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLCreateInstanceOperator._check_if_instance_exists")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_create(self, mock_hook, _check_if_instance_exists):
         _check_if_instance_exists.return_value = False
         mock_hook.return_value.create_instance.return_value = True
-        op = CloudSqlInstanceCreateOperator(
+        op = CloudSQLCreateInstanceOperator(
             project_id=PROJECT_ID,
             instance=INSTANCE_NAME,
             body=CREATE_BODY,
@@ -184,12 +184,12 @@ class TestCloudSql(unittest.TestCase):
         self.assertIsNone(result)
 
     @mock.patch("airflow.gcp.operators.cloud_sql"
-                ".CloudSqlInstanceCreateOperator._check_if_instance_exists")
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+                ".CloudSQLCreateInstanceOperator._check_if_instance_exists")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_create_missing_project_id(self, mock_hook, _check_if_instance_exists):
         _check_if_instance_exists.return_value = False
         mock_hook.return_value.create_instance.return_value = True
-        op = CloudSqlInstanceCreateOperator(
+        op = CloudSQLCreateInstanceOperator(
             instance=INSTANCE_NAME,
             body=CREATE_BODY,
             task_id="id"
@@ -206,12 +206,12 @@ class TestCloudSql(unittest.TestCase):
         self.assertIsNone(result)
 
     @mock.patch("airflow.gcp.operators.cloud_sql"
-                ".CloudSqlInstanceCreateOperator._check_if_instance_exists")
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+                ".CloudSQLCreateInstanceOperator._check_if_instance_exists")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_create_idempotent(self, mock_hook, _check_if_instance_exists):
         _check_if_instance_exists.return_value = True
         mock_hook.return_value.create_instance.return_value = True
-        op = CloudSqlInstanceCreateOperator(
+        op = CloudSQLCreateInstanceOperator(
             project_id=PROJECT_ID,
             instance=INSTANCE_NAME,
             body=CREATE_BODY,
@@ -225,10 +225,10 @@ class TestCloudSql(unittest.TestCase):
         mock_hook.return_value.create_instance.assert_not_called()
         self.assertIsNone(result)
 
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_create_should_throw_ex_when_empty_project_id(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = CloudSqlInstanceCreateOperator(
+            op = CloudSQLCreateInstanceOperator(
                 project_id="",
                 body=CREATE_BODY,
                 instance=INSTANCE_NAME,
@@ -239,10 +239,10 @@ class TestCloudSql(unittest.TestCase):
         self.assertIn("The required parameter 'project_id' is empty", str(err))
         mock_hook.assert_not_called()
 
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_create_should_throw_ex_when_empty_body(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = CloudSqlInstanceCreateOperator(
+            op = CloudSQLCreateInstanceOperator(
                 project_id=PROJECT_ID,
                 body={},
                 instance=INSTANCE_NAME,
@@ -253,10 +253,10 @@ class TestCloudSql(unittest.TestCase):
         self.assertIn("The required parameter 'body' is empty", str(err))
         mock_hook.assert_not_called()
 
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_create_should_throw_ex_when_empty_instance(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = CloudSqlInstanceCreateOperator(
+            op = CloudSQLCreateInstanceOperator(
                 project_id=PROJECT_ID,
                 body=CREATE_BODY,
                 instance="",
@@ -267,7 +267,7 @@ class TestCloudSql(unittest.TestCase):
         self.assertIn("The required parameter 'instance' is empty", str(err))
         mock_hook.assert_not_called()
 
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_create_should_validate_list_type(self, mock_hook):
         wrong_list_type_body = {
             "name": INSTANCE_NAME,
@@ -280,7 +280,7 @@ class TestCloudSql(unittest.TestCase):
             }
         }
         with self.assertRaises(AirflowException) as cm:
-            op = CloudSqlInstanceCreateOperator(
+            op = CloudSQLCreateInstanceOperator(
                 project_id=PROJECT_ID,
                 body=wrong_list_type_body,
                 instance=INSTANCE_NAME,
@@ -293,7 +293,7 @@ class TestCloudSql(unittest.TestCase):
         mock_hook.assert_called_once_with(api_version="v1beta4",
                                           gcp_conn_id="google_cloud_default")
 
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_create_should_validate_non_empty_fields(self, mock_hook):
         empty_tier_body = {
             "name": INSTANCE_NAME,
@@ -303,7 +303,7 @@ class TestCloudSql(unittest.TestCase):
             }
         }
         with self.assertRaises(AirflowException) as cm:
-            op = CloudSqlInstanceCreateOperator(
+            op = CloudSQLCreateInstanceOperator(
                 project_id=PROJECT_ID,
                 body=empty_tier_body,
                 instance=INSTANCE_NAME,
@@ -316,10 +316,10 @@ class TestCloudSql(unittest.TestCase):
         mock_hook.assert_called_once_with(api_version="v1beta4",
                                           gcp_conn_id="google_cloud_default")
 
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_patch(self, mock_hook):
         mock_hook.return_value.patch_instance.return_value = True
-        op = CloudSqlInstancePatchOperator(
+        op = CloudSQLInstancePatchOperator(
             project_id=PROJECT_ID,
             body=PATCH_BODY,
             instance=INSTANCE_NAME,
@@ -335,10 +335,10 @@ class TestCloudSql(unittest.TestCase):
         )
         self.assertTrue(result)
 
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_patch_missing_project_id(self, mock_hook):
         mock_hook.return_value.patch_instance.return_value = True
-        op = CloudSqlInstancePatchOperator(
+        op = CloudSQLInstancePatchOperator(
             body=PATCH_BODY,
             instance=INSTANCE_NAME,
             task_id="id"
@@ -354,13 +354,13 @@ class TestCloudSql(unittest.TestCase):
         self.assertTrue(result)
 
     @mock.patch("airflow.gcp.operators.cloud_sql"
-                ".CloudSqlInstancePatchOperator._check_if_instance_exists")
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+                ".CloudSQLInstancePatchOperator._check_if_instance_exists")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_patch_should_bubble_up_ex_if_not_exists(self, mock_hook,
                                                               _check_if_instance_exists):
         _check_if_instance_exists.return_value = False
         with self.assertRaises(AirflowException) as cm:
-            op = CloudSqlInstancePatchOperator(
+            op = CloudSQLInstancePatchOperator(
                 project_id=PROJECT_ID,
                 body=PATCH_BODY,
                 instance=INSTANCE_NAME,
@@ -374,11 +374,11 @@ class TestCloudSql(unittest.TestCase):
         mock_hook.return_value.patch_instance.assert_not_called()
 
     @mock.patch("airflow.gcp.operators.cloud_sql"
-                ".CloudSqlInstanceDeleteOperator._check_if_instance_exists")
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+                ".CloudSQLDeleteInstanceOperator._check_if_instance_exists")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_delete(self, mock_hook, _check_if_instance_exists):
         _check_if_instance_exists.return_value = True
-        op = CloudSqlInstanceDeleteOperator(
+        op = CloudSQLDeleteInstanceOperator(
             project_id=PROJECT_ID,
             instance=INSTANCE_NAME,
             task_id="id"
@@ -393,11 +393,11 @@ class TestCloudSql(unittest.TestCase):
         )
 
     @mock.patch("airflow.gcp.operators.cloud_sql"
-                ".CloudSqlInstanceDeleteOperator._check_if_instance_exists")
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+                ".CloudSQLDeleteInstanceOperator._check_if_instance_exists")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_delete_missing_project_id(self, mock_hook, _check_if_instance_exists):
         _check_if_instance_exists.return_value = True
-        op = CloudSqlInstanceDeleteOperator(
+        op = CloudSQLDeleteInstanceOperator(
             instance=INSTANCE_NAME,
             task_id="id"
         )
@@ -411,14 +411,14 @@ class TestCloudSql(unittest.TestCase):
         )
 
     @mock.patch("airflow.gcp.operators.cloud_sql"
-                ".CloudSqlInstanceDeleteOperator._check_if_instance_exists")
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+                ".CloudSQLDeleteInstanceOperator._check_if_instance_exists")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_delete_should_abort_and_succeed_if_not_exists(
             self,
             mock_hook,
             _check_if_instance_exists):
         _check_if_instance_exists.return_value = False
-        op = CloudSqlInstanceDeleteOperator(
+        op = CloudSQLDeleteInstanceOperator(
             project_id=PROJECT_ID,
             instance=INSTANCE_NAME,
             task_id="id"
@@ -430,11 +430,11 @@ class TestCloudSql(unittest.TestCase):
         mock_hook.return_value.delete_instance.assert_not_called()
 
     @mock.patch("airflow.gcp.operators.cloud_sql"
-                ".CloudSqlInstanceDatabaseCreateOperator._check_if_db_exists")
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+                ".CloudSQLCreateInstanceDatabaseOperator._check_if_db_exists")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_db_create(self, mock_hook, _check_if_db_exists):
         _check_if_db_exists.return_value = False
-        op = CloudSqlInstanceDatabaseCreateOperator(
+        op = CloudSQLCreateInstanceDatabaseOperator(
             project_id=PROJECT_ID,
             instance=INSTANCE_NAME,
             body=DATABASE_INSERT_BODY,
@@ -451,11 +451,11 @@ class TestCloudSql(unittest.TestCase):
         self.assertTrue(result)
 
     @mock.patch("airflow.gcp.operators.cloud_sql"
-                ".CloudSqlInstanceDatabaseCreateOperator._check_if_db_exists")
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+                ".CloudSQLCreateInstanceDatabaseOperator._check_if_db_exists")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_db_create_missing_project_id(self, mock_hook, _check_if_db_exists):
         _check_if_db_exists.return_value = False
-        op = CloudSqlInstanceDatabaseCreateOperator(
+        op = CloudSQLCreateInstanceDatabaseOperator(
             instance=INSTANCE_NAME,
             body=DATABASE_INSERT_BODY,
             task_id="id"
@@ -471,12 +471,12 @@ class TestCloudSql(unittest.TestCase):
         self.assertTrue(result)
 
     @mock.patch("airflow.gcp.operators.cloud_sql"
-                ".CloudSqlInstanceDatabaseCreateOperator._check_if_db_exists")
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+                ".CloudSQLCreateInstanceDatabaseOperator._check_if_db_exists")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_db_create_should_abort_and_succeed_if_exists(
             self, mock_hook, _check_if_db_exists):
         _check_if_db_exists.return_value = True
-        op = CloudSqlInstanceDatabaseCreateOperator(
+        op = CloudSQLCreateInstanceDatabaseOperator(
             project_id=PROJECT_ID,
             instance=INSTANCE_NAME,
             body=DATABASE_INSERT_BODY,
@@ -489,11 +489,11 @@ class TestCloudSql(unittest.TestCase):
         mock_hook.return_value.create_database.assert_not_called()
 
     @mock.patch("airflow.gcp.operators.cloud_sql"
-                ".CloudSqlInstanceDatabasePatchOperator._check_if_db_exists")
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+                ".CloudSQLPatchInstanceDatabaseOperator._check_if_db_exists")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_db_patch(self, mock_hook, _check_if_db_exists):
         _check_if_db_exists.return_value = True
-        op = CloudSqlInstanceDatabasePatchOperator(
+        op = CloudSQLPatchInstanceDatabaseOperator(
             project_id=PROJECT_ID,
             instance=INSTANCE_NAME,
             database=DB_NAME,
@@ -512,11 +512,11 @@ class TestCloudSql(unittest.TestCase):
         self.assertTrue(result)
 
     @mock.patch("airflow.gcp.operators.cloud_sql"
-                ".CloudSqlInstanceDatabasePatchOperator._check_if_db_exists")
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+                ".CloudSQLPatchInstanceDatabaseOperator._check_if_db_exists")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_db_patch_missing_project_id(self, mock_hook, _check_if_db_exists):
         _check_if_db_exists.return_value = True
-        op = CloudSqlInstanceDatabasePatchOperator(
+        op = CloudSQLPatchInstanceDatabaseOperator(
             instance=INSTANCE_NAME,
             database=DB_NAME,
             body=DATABASE_PATCH_BODY,
@@ -534,13 +534,13 @@ class TestCloudSql(unittest.TestCase):
         self.assertTrue(result)
 
     @mock.patch("airflow.gcp.operators.cloud_sql"
-                ".CloudSqlInstanceDatabasePatchOperator._check_if_db_exists")
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+                ".CloudSQLPatchInstanceDatabaseOperator._check_if_db_exists")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_db_patch_should_throw_ex_if_not_exists(
             self, mock_hook, _check_if_db_exists):
         _check_if_db_exists.return_value = False
         with self.assertRaises(AirflowException) as cm:
-            op = CloudSqlInstanceDatabasePatchOperator(
+            op = CloudSQLPatchInstanceDatabaseOperator(
                 project_id=PROJECT_ID,
                 instance=INSTANCE_NAME,
                 database=DB_NAME,
@@ -555,10 +555,10 @@ class TestCloudSql(unittest.TestCase):
                                           gcp_conn_id="google_cloud_default")
         mock_hook.return_value.patch_database.assert_not_called()
 
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_db_patch_should_throw_ex_when_empty_database(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = CloudSqlInstanceDatabasePatchOperator(
+            op = CloudSQLPatchInstanceDatabaseOperator(
                 project_id=PROJECT_ID,
                 instance=INSTANCE_NAME,
                 database="",
@@ -572,11 +572,11 @@ class TestCloudSql(unittest.TestCase):
         mock_hook.return_value.patch_database.assert_not_called()
 
     @mock.patch("airflow.gcp.operators.cloud_sql"
-                ".CloudSqlInstanceDatabaseDeleteOperator._check_if_db_exists")
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+                ".CloudSQLDeleteInstanceDatabaseOperator._check_if_db_exists")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_db_delete(self, mock_hook, _check_if_db_exists):
         _check_if_db_exists.return_value = True
-        op = CloudSqlInstanceDatabaseDeleteOperator(
+        op = CloudSQLDeleteInstanceDatabaseOperator(
             project_id=PROJECT_ID,
             instance=INSTANCE_NAME,
             database=DB_NAME,
@@ -593,11 +593,11 @@ class TestCloudSql(unittest.TestCase):
         )
 
     @mock.patch("airflow.gcp.operators.cloud_sql"
-                ".CloudSqlInstanceDatabaseDeleteOperator._check_if_db_exists")
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+                ".CloudSQLDeleteInstanceDatabaseOperator._check_if_db_exists")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_db_delete_missing_project_id(self, mock_hook, _check_if_db_exists):
         _check_if_db_exists.return_value = True
-        op = CloudSqlInstanceDatabaseDeleteOperator(
+        op = CloudSQLDeleteInstanceDatabaseOperator(
             instance=INSTANCE_NAME,
             database=DB_NAME,
             task_id="id"
@@ -613,12 +613,12 @@ class TestCloudSql(unittest.TestCase):
         )
 
     @mock.patch("airflow.gcp.operators.cloud_sql"
-                ".CloudSqlInstanceDatabaseDeleteOperator._check_if_db_exists")
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+                ".CloudSQLDeleteInstanceDatabaseOperator._check_if_db_exists")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_db_delete_should_abort_and_succeed_if_not_exists(
             self, mock_hook, _check_if_db_exists):
         _check_if_db_exists.return_value = False
-        op = CloudSqlInstanceDatabaseDeleteOperator(
+        op = CloudSQLDeleteInstanceDatabaseOperator(
             project_id=PROJECT_ID,
             instance=INSTANCE_NAME,
             database=DB_NAME,
@@ -630,10 +630,10 @@ class TestCloudSql(unittest.TestCase):
                                           gcp_conn_id="google_cloud_default")
         mock_hook.return_value.delete_database.assert_not_called()
 
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_export(self, mock_hook):
         mock_hook.return_value.export_instance.return_value = True
-        op = CloudSqlInstanceExportOperator(
+        op = CloudSQLExportInstanceOperator(
             project_id=PROJECT_ID,
             instance=INSTANCE_NAME,
             body=EXPORT_BODY,
@@ -649,10 +649,10 @@ class TestCloudSql(unittest.TestCase):
         )
         self.assertTrue(result)
 
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_export_missing_project_id(self, mock_hook):
         mock_hook.return_value.export_instance.return_value = True
-        op = CloudSqlInstanceExportOperator(
+        op = CloudSQLExportInstanceOperator(
             instance=INSTANCE_NAME,
             body=EXPORT_BODY,
             task_id="id"
@@ -667,10 +667,10 @@ class TestCloudSql(unittest.TestCase):
         )
         self.assertTrue(result)
 
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_import(self, mock_hook):
         mock_hook.return_value.export_instance.return_value = True
-        op = CloudSqlInstanceImportOperator(
+        op = CloudSQLImportInstanceOperator(
             project_id=PROJECT_ID,
             instance=INSTANCE_NAME,
             body=IMPORT_BODY,
@@ -686,10 +686,10 @@ class TestCloudSql(unittest.TestCase):
         )
         self.assertTrue(result)
 
-    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSqlHook")
+    @mock.patch("airflow.gcp.operators.cloud_sql.CloudSQLHook")
     def test_instance_import_missing_project_id(self, mock_hook):
         mock_hook.return_value.export_instance.return_value = True
-        op = CloudSqlInstanceImportOperator(
+        op = CloudSQLImportInstanceOperator(
             instance=INSTANCE_NAME,
             body=IMPORT_BODY,
             task_id="id"
@@ -761,7 +761,7 @@ class TestCloudSqlQueryValidation(unittest.TestCase):
                 use_ssl=use_ssl)
         self._setup_connections(get_connections, uri)
         with self.assertRaises(AirflowException) as cm:
-            op = CloudSqlQueryOperator(
+            op = CloudSQLExecuteQueryOperator(
                 sql=sql,
                 task_id='task_id'
             )
@@ -778,7 +778,7 @@ class TestCloudSqlQueryValidation(unittest.TestCase):
               "_the_limit_of_UNIX_socket_asdadadasadasd&" \
               "use_proxy=True&sql_proxy_use_tcp=False"
         self._setup_connections(get_connections, uri)
-        operator = CloudSqlQueryOperator(
+        operator = CloudSQLExecuteQueryOperator(
             sql=['SELECT * FROM TABLE'],
             task_id='task_id'
         )

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -97,11 +97,11 @@ HOOK = [
         "airflow.contrib.hooks.gcp_pubsub_hook.PubSubHook",
     ),
     (
-        "airflow.gcp.hooks.cloud_sql.CloudSqlHook",
+        "airflow.gcp.hooks.cloud_sql.CloudSQLHook",
         "airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook",
     ),
     (
-        "airflow.gcp.hooks.cloud_sql.CloudSqlDatabaseHook",
+        "airflow.gcp.hooks.cloud_sql.CloudSQLDatabaseHook",
         "airflow.contrib.hooks.gcp_sql_hook.CloudSqlDatabaseHook",
     ),
     (


### PR DESCRIPTION
PR contains changes regarding AIP-21 (renaming GCP operators and hooks)

* renamed GCP SQL operators and hooks
* added deprecation warnings in contrib modules
* updated UPDATING.md file
* fixed tests

- [ ] Description above provides context of the change
- [ ] Commit message contains [\[AIRFLOW-XXXX\]](https://issues.apache.org/jira/browse/AIRFLOW-XXXX) or `[AIRFLOW-XXXX]` for document-only changes
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
