### PR TITLE
[AIRFLOW-6145] [AIP-21] rename local to gcs service

### DIFF
--- a/airflow/contrib/operators/adls_to_gcs.py
+++ b/airflow/contrib/operators/adls_to_gcs.py
@@ -20,10 +20,24 @@
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.operators.adls_to_gcs import AdlsToGoogleCloudStorageOperator  # noqa
+from airflow.operators.adls_to_gcs import ADLSToGCSOperator
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.adls_to_gcs`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class AdlsToGoogleCloudStorageOperator(ADLSToGCSOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.operators.adls_to_gcs.ADLSToGCSOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.operators.adls_to_gcs.ADLSToGCSOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/bigquery_to_gcs.py
+++ b/airflow/contrib/operators/bigquery_to_gcs.py
@@ -20,10 +20,24 @@
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.operators.bigquery_to_gcs import BigQueryToCloudStorageOperator  # noqa
+from airflow.operators.bigquery_to_gcs import BigQueryToGCSOperator
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.bigquery_to_gcs`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class BigQueryToCloudStorageOperator(BigQueryToGCSOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.bigquery_to_gcs.BigQueryToGCSOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.bigquery_to_gcs.BigQueryToGCSOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/cassandra_to_gcs.py
+++ b/airflow/contrib/operators/cassandra_to_gcs.py
@@ -22,10 +22,24 @@ This module is deprecated. Please use `airflow.operators.cassandra_to_gcs`.
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.operators.cassandra_to_gcs import CassandraToGoogleCloudStorageOperator  # noqa
+from airflow.operators.cassandra_to_gcs import CassandraToGCSOperator
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.cassandra_to_gcs`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class CassandraToGoogleCloudStorageOperator(CassandraToGCSOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.operators.cassandra_to_gcs.CassandraToGCSOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.operators.cassandra_to_gcs.CassandraToGCSOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/file_to_gcs.py
+++ b/airflow/contrib/operators/file_to_gcs.py
@@ -22,10 +22,24 @@ This module is deprecated. Please use `airflow.operators.local_to_gcs`.
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.operators.local_to_gcs import FileToGoogleCloudStorageOperator  # noqa
+from airflow.operators.local_to_gcs import LocalFilesystemToGCSOperator
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.local_to_gcs`,",
     DeprecationWarning, stacklevel=2
 )
+
+
+class FileToGoogleCloudStorageOperator(LocalFilesystemToGCSOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.local_to_gcs.LocalFilesystemToGCSOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.local_to_gcs.LocalFilesystemToGCSOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcs_to_gcs.py
+++ b/airflow/contrib/operators/gcs_to_gcs.py
@@ -22,10 +22,24 @@ This module is deprecated. Please use `airflow.operators.gcs_to_gcs`.
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.operators.gcs_to_gcs import GoogleCloudStorageToGoogleCloudStorageOperator  # noqa
+from airflow.operators.gcs_to_gcs import GCSToGCSOperator
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.gcs_to_gcs`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class GoogleCloudStorageToGoogleCloudStorageOperator(GCSToGCSOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.gcs_to_gcs.GCSToGCSOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.gcs_to_gcs.GCSToGCSOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/mssql_to_gcs.py
+++ b/airflow/contrib/operators/mssql_to_gcs.py
@@ -20,10 +20,24 @@
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.operators.mssql_to_gcs import MsSqlToGoogleCloudStorageOperator  # noqa
+from airflow.operators.mssql_to_gcs import MSSQLToGCSOperator
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.mssql_to_gcs`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class MsSqlToGoogleCloudStorageOperator(MSSQLToGCSOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.operators.mssql_to_gcs.MSSQLToGCSOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.operators.mssql_to_gcs.MSSQLToGCSOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/mysql_to_gcs.py
+++ b/airflow/contrib/operators/mysql_to_gcs.py
@@ -20,10 +20,24 @@
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.operators.mysql_to_gcs import MySqlToGoogleCloudStorageOperator  # noqa
+from airflow.operators.mysql_to_gcs import MySQLToGCSOperator
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.mysql_to_gcs`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class MySqlToGoogleCloudStorageOperator(MySQLToGCSOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.operators.mysql_to_gcs.MySQLToGCSOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.operators.mysql_to_gcs.MySQLToGCSOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/postgres_to_gcs_operator.py
+++ b/airflow/contrib/operators/postgres_to_gcs_operator.py
@@ -20,10 +20,23 @@
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.operators.postgres_to_gcs import PostgresToGoogleCloudStorageOperator  # noqa
+from airflow.operators.postgres_to_gcs import PostgresToGCSOperator
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.postgres_to_gcs`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class PostgresToGoogleCloudStorageOperator(PostgresToGCSOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.operators.postgres_to_gcs.PostgresToGCSOperator`.
+    """
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.operators.postgres_to_gcs.PostgresToGCSOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/sql_to_gcs.py
+++ b/airflow/contrib/operators/sql_to_gcs.py
@@ -20,10 +20,24 @@
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.operators.sql_to_gcs import BaseSQLToGoogleCloudStorageOperator  # noqa
+from airflow.operators.sql_to_gcs import BaseSQLToGCSOperator
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.sql_to_gcs`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class BaseSQLToGoogleCloudStorageOperator(BaseSQLToGCSOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.operators.sql_to_gcs.BaseSQLToGCSOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.operators.sql_to_gcs.BaseSQLToGCSOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/example_dags/example_gcs_to_gcs.py
+++ b/airflow/example_dags/example_gcs_to_gcs.py
@@ -23,7 +23,7 @@ Example Airflow DAG for Google Cloud Storage to Google Cloud Storage transfer op
 import os
 
 from airflow import models
-from airflow.operators.gcs_to_gcs import GoogleCloudStorageSynchronizeBuckets
+from airflow.operators.gcs_to_gcs import GCSSynchronizeBuckets
 from airflow.utils.dates import days_ago
 
 default_args = {"start_date": days_ago(1)}
@@ -37,17 +37,16 @@ BUCKET_2_DST = os.environ.get("GCP_GCS_BUCKET_2_DST", "test-gcs-sync-2-dst")
 BUCKET_3_SRC = os.environ.get("GCP_GCS_BUCKET_3_SRC", "test-gcs-sync-3-src")
 BUCKET_3_DST = os.environ.get("GCP_GCS_BUCKET_3_DST", "test-gcs-sync-3-dst")
 
-
 with models.DAG(
     "example_gcs_to_gcs", default_args=default_args, schedule_interval=None, tags=['example']
 ) as dag:
-    sync_full_bucket = GoogleCloudStorageSynchronizeBuckets(
+    sync_full_bucket = GCSSynchronizeBuckets(
         task_id="sync-full-bucket",
         source_bucket=BUCKET_1_SRC,
         destination_bucket=BUCKET_1_DST
     )
 
-    sync_to_subdirectory_and_delete_extra_files = GoogleCloudStorageSynchronizeBuckets(
+    sync_to_subdirectory_and_delete_extra_files = GCSSynchronizeBuckets(
         task_id="sync_to_subdirectory_and_delete_extra_files",
         source_bucket=BUCKET_1_SRC,
         destination_bucket=BUCKET_1_DST,
@@ -55,7 +54,7 @@ with models.DAG(
         delete_extra_files=True,
     )
 
-    sync_from_subdirectory_and_allow_overwrite_and_non_recursive = GoogleCloudStorageSynchronizeBuckets(
+    sync_from_subdirectory_and_allow_overwrite_and_non_recursive = GCSSynchronizeBuckets(
         task_id="sync_from_subdirectory_and_allow_overwrite_and_non_recursive",
         source_bucket=BUCKET_1_SRC,
         source_object="subdir/",

--- a/airflow/example_dags/example_postgres_to_gcs.py
+++ b/airflow/example_dags/example_postgres_to_gcs.py
@@ -20,7 +20,7 @@
 Example DAG using PostgresToGoogleCloudStorageOperator.
 """
 from airflow import models
-from airflow.operators.postgres_to_gcs import PostgresToGoogleCloudStorageOperator
+from airflow.operators.postgres_to_gcs import PostgresToGCSOperator
 from airflow.utils.dates import days_ago
 
 GCS_BUCKET = "postgres_to_gcs_example"
@@ -35,7 +35,7 @@ with models.DAG(
     schedule_interval=None,  # Override to match your needs
     tags=['example'],
 ) as dag:
-    upload_data = PostgresToGoogleCloudStorageOperator(
+    upload_data = PostgresToGCSOperator(
         task_id="get_data",
         sql=SQL_QUERY,
         bucket=GCS_BUCKET,

--- a/airflow/gcp/example_dags/example_bigquery.py
+++ b/airflow/gcp/example_dags/example_bigquery.py
@@ -32,7 +32,7 @@ from airflow.gcp.operators.bigquery import (
 )
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.bigquery_to_bigquery import BigQueryToBigQueryOperator
-from airflow.operators.bigquery_to_gcs import BigQueryToCloudStorageOperator
+from airflow.operators.bigquery_to_gcs import BigQueryToGCSOperator
 from airflow.utils.dates import days_ago
 
 # 0x06012c8cf97BEaD5deAe237070F9587f8E7A266d = CryptoKitties contract address
@@ -165,7 +165,7 @@ with models.DAG(
         destination_project_dataset_table="{}.copy_of_selected_data_from_external_table".format(DATASET_NAME),
     )
 
-    bigquery_to_gcs = BigQueryToCloudStorageOperator(
+    bigquery_to_gcs = BigQueryToGCSOperator(
         task_id="bigquery_to_gcs",
         source_project_dataset_table="{}.selected_data_from_external_table".format(DATASET_NAME),
         destination_cloud_storage_uris=["gs://{}/export-bigquery.csv".format(DATA_EXPORT_BUCKET_NAME)],

--- a/airflow/gcp/example_dags/example_gcs.py
+++ b/airflow/gcp/example_dags/example_gcs.py
@@ -28,8 +28,8 @@ from airflow.gcp.operators.gcs import (
     GcsFileTransformOperator, GCSListObjectsOperator, GCSObjectCreateAclEntryOperator, GCSToLocalOperator,
 )
 from airflow.operators.bash_operator import BashOperator
-from airflow.operators.gcs_to_gcs import GoogleCloudStorageToGoogleCloudStorageOperator
-from airflow.operators.local_to_gcs import FileToGoogleCloudStorageOperator
+from airflow.operators.gcs_to_gcs import GCSToGCSOperator
+from airflow.operators.local_to_gcs import LocalFilesystemToGCSOperator
 from airflow.utils.dates import days_ago
 
 default_args = {"start_date": days_ago(1)}
@@ -76,7 +76,7 @@ with models.DAG(
         bash_command="echo \"{{ task_instance.xcom_pull('list_buckets') }}\"",
     )
 
-    upload_file = FileToGoogleCloudStorageOperator(
+    upload_file = LocalFilesystemToGCSOperator(
         task_id="upload_file",
         src=PATH_TO_UPLOAD_FILE,
         dst=BUCKET_FILE_LOCATION,
@@ -115,7 +115,7 @@ with models.DAG(
         filename=PATH_TO_SAVED_FILE,
     )
 
-    copy_file = GoogleCloudStorageToGoogleCloudStorageOperator(
+    copy_file = GCSToGCSOperator(
         task_id="copy_file",
         source_bucket=BUCKET_1,
         source_object=BUCKET_FILE_LOCATION,

--- a/airflow/gcp/operators/cloud_storage_transfer_service.py
+++ b/airflow/gcp/operators/cloud_storage_transfer_service.py
@@ -715,7 +715,7 @@ class CloudDataTransferServiceGCSToGCSOperator(BaseOperator):
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GoogleCloudStorageToGoogleCloudStorageOperator`
+        :ref:`howto/operator:GCSToGCSOperator`
 
     **Example**:
 

--- a/airflow/operators/adls_to_gcs.py
+++ b/airflow/operators/adls_to_gcs.py
@@ -31,7 +31,7 @@ from airflow.providers.microsoft.azure.operators.adls_list import AzureDataLakeS
 from airflow.utils.decorators import apply_defaults
 
 
-class AdlsToGoogleCloudStorageOperator(AzureDataLakeStorageListOperator):
+class ADLSToGCSOperator(AzureDataLakeStorageListOperator):
     """
     Synchronizes an Azure Data Lake Storage path with a GCS bucket
 

--- a/airflow/operators/bigquery_to_gcs.py
+++ b/airflow/operators/bigquery_to_gcs.py
@@ -27,7 +27,7 @@ from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
 
-class BigQueryToCloudStorageOperator(BaseOperator):
+class BigQueryToGCSOperator(BaseOperator):
     """
     Transfers a BigQuery table to a Google Cloud Storage bucket.
 

--- a/airflow/operators/cassandra_to_gcs.py
+++ b/airflow/operators/cassandra_to_gcs.py
@@ -39,7 +39,7 @@ from airflow.providers.apache.cassandra.hooks.cassandra import CassandraHook
 from airflow.utils.decorators import apply_defaults
 
 
-class CassandraToGoogleCloudStorageOperator(BaseOperator):
+class CassandraToGCSOperator(BaseOperator):
     """
     Copy data from Cassandra to Google Cloud Storage in JSON format
 
@@ -347,7 +347,7 @@ class CassandraToGoogleCloudStorageOperator(BaseOperator):
         """
         Check if type is a simple type.
         """
-        return type_.cassname in CassandraToGoogleCloudStorageOperator.CQL_TYPE_MAP
+        return type_.cassname in CassandraToGCSOperator.CQL_TYPE_MAP
 
     @staticmethod
     def is_array_type(type_: Any) -> bool:
@@ -369,7 +369,7 @@ class CassandraToGoogleCloudStorageOperator(BaseOperator):
         Converts type to equivalent BQ type.
         """
         if cls.is_simple_type(type_):
-            return CassandraToGoogleCloudStorageOperator.CQL_TYPE_MAP[type_.cassname]
+            return CassandraToGCSOperator.CQL_TYPE_MAP[type_.cassname]
         elif cls.is_record_type(type_):
             return 'RECORD'
         elif cls.is_array_type(type_):

--- a/airflow/operators/gcs_to_gcs.py
+++ b/airflow/operators/gcs_to_gcs.py
@@ -30,13 +30,13 @@ from airflow.utils.decorators import apply_defaults
 WILDCARD = '*'
 
 
-class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
+class GCSToGCSOperator(BaseOperator):
     """
     Copies objects from a bucket to another, with renaming if requested.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GoogleCloudStorageToGoogleCloudStorageOperator`
+        :ref:`howto/operator:GCSToGCSOperator`
 
     :param source_bucket: The source Google Cloud Storage bucket where the
          object is. (templated)
@@ -87,7 +87,7 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
     ``sales/sales-2017/january.avro`` in the ``data`` bucket to the file named
     ``copied_sales/2017/january-backup.avro`` in the ``data_backup`` bucket ::
 
-        copy_single_file = GoogleCloudStorageToGoogleCloudStorageOperator(
+        copy_single_file = GCSToGCSOperator(
             task_id='copy_single_file',
             source_bucket='data',
             source_object='sales/sales-2017/january.avro',
@@ -100,7 +100,7 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
     folder (i.e. with names starting with that prefix) in ``data`` bucket to the
     ``copied_sales/2017`` folder in the ``data_backup`` bucket. ::
 
-        copy_files = GoogleCloudStorageToGoogleCloudStorageOperator(
+        copy_files = GCSToGCSOperator(
             task_id='copy_files',
             source_bucket='data',
             source_object='sales/sales-2017/*.avro',
@@ -114,7 +114,7 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
     same folder in the ``data_backup`` bucket, deleting the original files in the
     process. ::
 
-        move_files = GoogleCloudStorageToGoogleCloudStorageOperator(
+        move_files = GCSToGCSOperator(
             task_id='move_files',
             source_bucket='data',
             source_object='sales/sales-2017/*.avro',
@@ -216,7 +216,7 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
             hook.delete(self.source_bucket, source_object)
 
 
-class GoogleCloudStorageSynchronizeBuckets(BaseOperator):
+class GCSSynchronizeBuckets(BaseOperator):
     """
     Synchronizes the contents of the buckets or bucket's directories in the Google Cloud Services.
 
@@ -229,7 +229,7 @@ class GoogleCloudStorageSynchronizeBuckets(BaseOperator):
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GoogleCloudStorageSynchronizeBuckets`
+        :ref:`howto/operator:GCSSynchronizeBuckets`
 
     :param source_bucket: The name of the bucket containing the source objects.
     :type source_bucket: str

--- a/airflow/operators/local_to_gcs.py
+++ b/airflow/operators/local_to_gcs.py
@@ -26,7 +26,7 @@ from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
 
-class FileToGoogleCloudStorageOperator(BaseOperator):
+class LocalFilesystemToGCSOperator(BaseOperator):
     """
     Uploads a file to Google Cloud Storage.
     Optionally can compress the file for upload.

--- a/airflow/operators/mssql_to_gcs.py
+++ b/airflow/operators/mssql_to_gcs.py
@@ -23,11 +23,11 @@ MsSQL to GCS operator.
 import decimal
 
 from airflow.hooks.mssql_hook import MsSqlHook
-from airflow.operators.sql_to_gcs import BaseSQLToGoogleCloudStorageOperator
+from airflow.operators.sql_to_gcs import BaseSQLToGCSOperator
 from airflow.utils.decorators import apply_defaults
 
 
-class MsSqlToGoogleCloudStorageOperator(BaseSQLToGoogleCloudStorageOperator):
+class MSSQLToGCSOperator(BaseSQLToGCSOperator):
     """Copy data from Microsoft SQL Server to Google Cloud Storage
     in JSON or CSV format.
 

--- a/airflow/operators/mysql_to_gcs.py
+++ b/airflow/operators/mysql_to_gcs.py
@@ -28,11 +28,11 @@ from decimal import Decimal
 from MySQLdb.constants import FIELD_TYPE
 
 from airflow.hooks.mysql_hook import MySqlHook
-from airflow.operators.sql_to_gcs import BaseSQLToGoogleCloudStorageOperator
+from airflow.operators.sql_to_gcs import BaseSQLToGCSOperator
 from airflow.utils.decorators import apply_defaults
 
 
-class MySqlToGoogleCloudStorageOperator(BaseSQLToGoogleCloudStorageOperator):
+class MySQLToGCSOperator(BaseSQLToGCSOperator):
     """Copy data from MySQL to Google Cloud Storage in JSON or CSV format.
 
     :param mysql_conn_id: Reference to a specific MySQL hook.

--- a/airflow/operators/postgres_to_gcs.py
+++ b/airflow/operators/postgres_to_gcs.py
@@ -26,11 +26,11 @@ import time
 from decimal import Decimal
 
 from airflow.hooks.postgres_hook import PostgresHook
-from airflow.operators.sql_to_gcs import BaseSQLToGoogleCloudStorageOperator
+from airflow.operators.sql_to_gcs import BaseSQLToGCSOperator
 from airflow.utils.decorators import apply_defaults
 
 
-class PostgresToGoogleCloudStorageOperator(BaseSQLToGoogleCloudStorageOperator):
+class PostgresToGCSOperator(BaseSQLToGCSOperator):
     """
     Copy data from Postgres to Google Cloud Storage in JSON or CSV format.
 

--- a/airflow/operators/sql_to_gcs.py
+++ b/airflow/operators/sql_to_gcs.py
@@ -32,7 +32,7 @@ from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
 
-class BaseSQLToGoogleCloudStorageOperator(BaseOperator, metaclass=abc.ABCMeta):
+class BaseSQLToGCSOperator(BaseOperator, metaclass=abc.ABCMeta):
     """
     :param sql: The SQL to execute.
     :type sql: str
@@ -96,7 +96,7 @@ class BaseSQLToGoogleCloudStorageOperator(BaseOperator, metaclass=abc.ABCMeta):
                  delegate_to=None,
                  *args,
                  **kwargs):
-        super(BaseSQLToGoogleCloudStorageOperator, self).__init__(*args, **kwargs)
+        super(BaseSQLToGCSOperator, self).__init__(*args, **kwargs)
 
         if google_cloud_storage_conn_id:
             warnings.warn(

--- a/docs/howto/operator/gcp/gcs_to_gcs.rst
+++ b/docs/howto/operator/gcp/gcs_to_gcs.rst
@@ -59,13 +59,13 @@ In the next section they will be described.
 Operators
 ---------
 
-.. _howto/operator:GoogleCloudStorageToGoogleCloudStorageOperator:
+.. _howto/operator:GCSToGCSOperator:
 
-GoogleCloudStorageToGoogleCloudStorageOperator
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+GCSToGCSOperator
+~~~~~~~~~~~~~~~~
 
 
-:class:`~airflow.operators.gcs_to_gcs.GoogleCloudStorageToGoogleCloudStorageOperator` allows you to copy
+:class:`~airflow.operators.gcs_to_gcs.GCSToGCSOperator` allows you to copy
 one or more files. The copying always takes place without taking into account the initial state of
 the destination bucket.
 
@@ -79,12 +79,12 @@ well as based on the file modification date.
 The way this operator works can be compared to the ``cp`` command.
 
 
-.. _howto/operator:GoogleCloudStorageSynchronizeBuckets:
+.. _howto/operator:GCSSynchronizeBuckets:
 
-GoogleCloudStorageSynchronizeBuckets
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+GCSSynchronizeBuckets
+~~~~~~~~~~~~~~~~~~~~~
 
-The :class:`~airflow.operators.gcs_to_gcs.GoogleCloudStorageSynchronizeBuckets`
+The :class:`~airflow.operators.gcs_to_gcs.GCSSynchronizeBuckets`
 operator checks the initial state of the destination bucket, and then compares it with the source bucket.
 Based on this, it creates an operation plan that describes which objects should be deleted from
 the destination bucket, which should be overwritten, and which should be copied.

--- a/tests/operators/test_adls_to_gcs_operator.py
+++ b/tests/operators/test_adls_to_gcs_operator.py
@@ -21,7 +21,7 @@ import unittest
 
 import mock
 
-from airflow.operators.adls_to_gcs import AdlsToGoogleCloudStorageOperator
+from airflow.operators.adls_to_gcs import ADLSToGCSOperator
 
 TASK_ID = 'test-adls-gcs-operator'
 ADLS_PATH_1 = '*'
@@ -36,7 +36,7 @@ class TestAdlsToGoogleCloudStorageOperator(unittest.TestCase):
     def test_init(self):
         """Test AdlsToGoogleCloudStorageOperator instance is properly initialized."""
 
-        operator = AdlsToGoogleCloudStorageOperator(
+        operator = ADLSToGCSOperator(
             task_id=TASK_ID,
             src_adls=ADLS_PATH_1,
             dest_gcs=GCS_PATH,
@@ -59,7 +59,7 @@ class TestAdlsToGoogleCloudStorageOperator(unittest.TestCase):
     def test_execute(self, gcs_mock_hook, adls_one_mock_hook, adls_two_mock_hook):
         """Test the execute function when the run is successful."""
 
-        operator = AdlsToGoogleCloudStorageOperator(
+        operator = ADLSToGCSOperator(
             task_id=TASK_ID,
             src_adls=ADLS_PATH_1,
             dest_gcs=GCS_PATH,
@@ -108,7 +108,7 @@ class TestAdlsToGoogleCloudStorageOperator(unittest.TestCase):
     def test_execute_with_gzip(self, gcs_mock_hook, adls_one_mock_hook, adls_two_mock_hook):
         """Test the execute function when the run is successful."""
 
-        operator = AdlsToGoogleCloudStorageOperator(
+        operator = ADLSToGCSOperator(
             task_id=TASK_ID,
             src_adls=ADLS_PATH_1,
             dest_gcs=GCS_PATH,

--- a/tests/operators/test_bigquery_to_gcs.py
+++ b/tests/operators/test_bigquery_to_gcs.py
@@ -21,7 +21,7 @@ import unittest
 
 import mock
 
-from airflow.operators.bigquery_to_gcs import BigQueryToCloudStorageOperator
+from airflow.operators.bigquery_to_gcs import BigQueryToGCSOperator
 
 TASK_ID = 'test-bq-create-table-operator'
 TEST_DATASET = 'test-dataset'
@@ -40,7 +40,7 @@ class TestBigQueryToCloudStorageOperator(unittest.TestCase):
         print_header = True
         labels = {'k1': 'v1'}
 
-        operator = BigQueryToCloudStorageOperator(
+        operator = BigQueryToGCSOperator(
             task_id=TASK_ID,
             source_project_dataset_table=source_project_dataset_table,
             destination_cloud_storage_uris=destination_cloud_storage_uris,

--- a/tests/operators/test_cassandra_to_gcs.py
+++ b/tests/operators/test_cassandra_to_gcs.py
@@ -22,7 +22,7 @@ from unittest import mock
 
 from mock import call
 
-from airflow.operators.cassandra_to_gcs import CassandraToGoogleCloudStorageOperator
+from airflow.operators.cassandra_to_gcs import CassandraToGCSOperator
 
 TMP_FILE_NAME = "temp-file"
 
@@ -40,7 +40,7 @@ class TestCassandraToGCS(unittest.TestCase):
         gzip = True
         mock_tempfile.return_value.name = TMP_FILE_NAME
 
-        operator = CassandraToGoogleCloudStorageOperator(
+        operator = CassandraToGCSOperator(
             task_id="test-cas-to-gcs",
             cql="select * from keyspace1.table1",
             bucket=test_bucket,
@@ -58,7 +58,7 @@ class TestCassandraToGCS(unittest.TestCase):
         mock_upload.assert_has_calls([call_schema, call_data], any_order=True)
 
     def test_convert_value(self):
-        op = CassandraToGoogleCloudStorageOperator
+        op = CassandraToGCSOperator
         self.assertEqual(op.convert_value(None), None)
         self.assertEqual(op.convert_value(1), 1)
         self.assertEqual(op.convert_value(1.0), 1.0)

--- a/tests/operators/test_gcs_to_gcs.py
+++ b/tests/operators/test_gcs_to_gcs.py
@@ -23,9 +23,7 @@ from datetime import datetime
 import mock
 
 from airflow.exceptions import AirflowException
-from airflow.operators.gcs_to_gcs import (
-    WILDCARD, GoogleCloudStorageSynchronizeBuckets, GoogleCloudStorageToGoogleCloudStorageOperator,
-)
+from airflow.operators.gcs_to_gcs import WILDCARD, GCSSynchronizeBuckets, GCSToGCSOperator
 
 TASK_ID = 'test-gcs-to-gcs-operator'
 TEST_BUCKET = 'test-bucket'
@@ -54,12 +52,12 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
     no_suffix: test_object*
     prefix_and_suffix: test*object
 
-    Also tests the destionation_object as prefix when the wildcard is used.
+    Also tests the destination_object as prefix when the wildcard is used.
     """
 
     @mock.patch('airflow.operators.gcs_to_gcs.GCSHook')
     def test_execute_no_prefix(self, mock_hook):
-        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+        operator = GCSToGCSOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_WILDCARD_PREFIX,
             destination_bucket=DESTINATION_BUCKET)
@@ -71,7 +69,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
 
     @mock.patch('airflow.operators.gcs_to_gcs.GCSHook')
     def test_execute_no_suffix(self, mock_hook):
-        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+        operator = GCSToGCSOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_WILDCARD_SUFFIX,
             destination_bucket=DESTINATION_BUCKET)
@@ -83,7 +81,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
 
     @mock.patch('airflow.operators.gcs_to_gcs.GCSHook')
     def test_execute_prefix_and_suffix(self, mock_hook):
-        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+        operator = GCSToGCSOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_WILDCARD_MIDDLE,
             destination_bucket=DESTINATION_BUCKET)
@@ -98,7 +96,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
     @mock.patch('airflow.operators.gcs_to_gcs.GCSHook')
     def test_execute_wildcard_with_destination_object(self, mock_hook):
         mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
-        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+        operator = GCSToGCSOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_WILDCARD_FILENAME,
             destination_bucket=DESTINATION_BUCKET,
@@ -116,7 +114,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
     @mock.patch('airflow.operators.gcs_to_gcs.GCSHook')
     def test_execute_wildcard_with_destination_object_retained_prefix(self, mock_hook):
         mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
-        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+        operator = GCSToGCSOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_WILDCARD_FILENAME,
             destination_bucket=DESTINATION_BUCKET,
@@ -136,7 +134,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
     @mock.patch('airflow.operators.gcs_to_gcs.GCSHook')
     def test_execute_wildcard_without_destination_object(self, mock_hook):
         mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
-        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+        operator = GCSToGCSOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_WILDCARD_FILENAME,
             destination_bucket=DESTINATION_BUCKET)
@@ -153,7 +151,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
     @mock.patch('airflow.operators.gcs_to_gcs.GCSHook')
     def test_execute_wildcard_empty_destination_object(self, mock_hook):
         mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
-        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+        operator = GCSToGCSOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_WILDCARD_FILENAME,
             destination_bucket=DESTINATION_BUCKET,
@@ -171,7 +169,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
     @mock.patch('airflow.operators.gcs_to_gcs.GCSHook')
     def test_execute_last_modified_time(self, mock_hook):
         mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
-        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+        operator = GCSToGCSOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_WILDCARD_FILENAME,
             destination_bucket=DESTINATION_BUCKET,
@@ -190,7 +188,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
     def test_wc_with_last_modified_time_with_all_true_cond(self, mock_hook):
         mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
         mock_hook.return_value.is_updated_after.side_effect = [True, True, True]
-        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+        operator = GCSToGCSOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_WILDCARD_FILENAME,
             destination_bucket=DESTINATION_BUCKET,
@@ -209,7 +207,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
     def test_wc_with_last_modified_time_with_one_true_cond(self, mock_hook):
         mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
         mock_hook.return_value.is_updated_after.side_effect = [True, False, False]
-        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+        operator = GCSToGCSOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_WILDCARD_FILENAME,
             destination_bucket=DESTINATION_BUCKET,
@@ -223,7 +221,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
     @mock.patch('airflow.operators.gcs_to_gcs.GCSHook')
     def test_wc_with_no_last_modified_time(self, mock_hook):
         mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
-        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+        operator = GCSToGCSOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_WILDCARD_FILENAME,
             destination_bucket=DESTINATION_BUCKET,
@@ -241,7 +239,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
     @mock.patch('airflow.operators.gcs_to_gcs.GCSHook')
     def test_no_prefix_with_last_modified_time_with_true_cond(self, mock_hook):
         mock_hook.return_value.is_updated_after.return_value = True
-        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+        operator = GCSToGCSOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_NO_WILDCARD,
             destination_bucket=DESTINATION_BUCKET,
@@ -254,7 +252,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
 
     @mock.patch('airflow.operators.gcs_to_gcs.GCSHook')
     def test_execute_no_prefix_with_no_last_modified_time(self, mock_hook):
-        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+        operator = GCSToGCSOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_NO_WILDCARD,
             destination_bucket=DESTINATION_BUCKET,
@@ -268,7 +266,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
     @mock.patch('airflow.operators.gcs_to_gcs.GCSHook')
     def test_no_prefix_with_last_modified_time_with_false_cond(self, mock_hook):
         mock_hook.return_value.is_updated_after.return_value = False
-        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+        operator = GCSToGCSOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_NO_WILDCARD,
             destination_bucket=DESTINATION_BUCKET,
@@ -281,7 +279,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
     @mock.patch('airflow.operators.gcs_to_gcs.GCSHook')
     def test_execute_more_than_1_wildcard(self, mock_hook):
         mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
-        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+        operator = GCSToGCSOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_MULTIPLE_WILDCARDS,
             destination_bucket=DESTINATION_BUCKET,
@@ -298,7 +296,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
     @mock.patch('airflow.operators.gcs_to_gcs.GCSHook')
     def test_execute_with_empty_destination_bucket(self, mock_hook):
         mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
-        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+        operator = GCSToGCSOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_NO_WILDCARD,
             destination_bucket=None,
@@ -317,7 +315,7 @@ class TestGoogleCloudStorageSync(unittest.TestCase):
 
     @mock.patch('airflow.operators.gcs_to_gcs.GCSHook')
     def test_execute(self, mock_hook):
-        task = GoogleCloudStorageSynchronizeBuckets(
+        task = GCSSynchronizeBuckets(
             task_id="task-id",
             source_bucket="SOURCE_BUCKET",
             destination_bucket="DESTINATION_BUCKET",

--- a/tests/operators/test_local_to_gcs.py
+++ b/tests/operators/test_local_to_gcs.py
@@ -24,7 +24,7 @@ import unittest
 import mock
 
 from airflow import DAG
-from airflow.operators.local_to_gcs import FileToGoogleCloudStorageOperator
+from airflow.operators.local_to_gcs import LocalFilesystemToGCSOperator
 
 
 class TestFileToGcsOperator(unittest.TestCase):
@@ -45,7 +45,7 @@ class TestFileToGcsOperator(unittest.TestCase):
         self.dag = DAG('test_dag_id', default_args=args)
 
     def test_init(self):
-        operator = FileToGoogleCloudStorageOperator(
+        operator = LocalFilesystemToGCSOperator(
             task_id='file_to_gcs_operator',
             dag=self.dag,
             **self._config
@@ -60,7 +60,7 @@ class TestFileToGcsOperator(unittest.TestCase):
                 autospec=True)
     def test_execute(self, mock_hook):
         mock_instance = mock_hook.return_value
-        operator = FileToGoogleCloudStorageOperator(
+        operator = LocalFilesystemToGCSOperator(
             task_id='gcs_to_file_sensor',
             dag=self.dag,
             **self._config

--- a/tests/operators/test_mssql_to_gcs.py
+++ b/tests/operators/test_mssql_to_gcs.py
@@ -21,7 +21,7 @@ import unittest
 
 import mock
 
-from airflow.operators.mssql_to_gcs import MsSqlToGoogleCloudStorageOperator
+from airflow.operators.mssql_to_gcs import MSSQLToGCSOperator
 
 TASK_ID = 'test-mssql-to-gcs'
 MSSQL_CONN_ID = 'mssql_conn_test'
@@ -55,7 +55,7 @@ class TestMsSqlToGoogleCloudStorageOperator(unittest.TestCase):
 
     def test_init(self):
         """Test MySqlToGoogleCloudStorageOperator instance is properly initialized."""
-        op = MsSqlToGoogleCloudStorageOperator(
+        op = MSSQLToGCSOperator(
             task_id=TASK_ID, sql=SQL, bucket=BUCKET, filename=JSON_FILENAME)
         self.assertEqual(op.task_id, TASK_ID)
         self.assertEqual(op.sql, SQL)
@@ -66,7 +66,7 @@ class TestMsSqlToGoogleCloudStorageOperator(unittest.TestCase):
     @mock.patch('airflow.operators.sql_to_gcs.GCSHook')
     def test_exec_success_json(self, gcs_hook_mock_class, mssql_hook_mock_class):
         """Test successful run of execute function for JSON"""
-        op = MsSqlToGoogleCloudStorageOperator(
+        op = MSSQLToGCSOperator(
             task_id=TASK_ID,
             mssql_conn_id=MSSQL_CONN_ID,
             sql=SQL,
@@ -117,7 +117,7 @@ class TestMsSqlToGoogleCloudStorageOperator(unittest.TestCase):
 
         gcs_hook_mock.upload.side_effect = _assert_upload
 
-        op = MsSqlToGoogleCloudStorageOperator(
+        op = MSSQLToGCSOperator(
             task_id=TASK_ID,
             sql=SQL,
             bucket=BUCKET,
@@ -142,7 +142,7 @@ class TestMsSqlToGoogleCloudStorageOperator(unittest.TestCase):
 
         gcs_hook_mock.upload.side_effect = _assert_upload
 
-        op = MsSqlToGoogleCloudStorageOperator(
+        op = MSSQLToGCSOperator(
             task_id=TASK_ID,
             sql=SQL,
             bucket=BUCKET,

--- a/tests/operators/test_mysql_to_gcs.py
+++ b/tests/operators/test_mysql_to_gcs.py
@@ -25,7 +25,7 @@ import mock
 from _mysql_exceptions import ProgrammingError
 from parameterized import parameterized
 
-from airflow.operators.mysql_to_gcs import MySqlToGoogleCloudStorageOperator
+from airflow.operators.mysql_to_gcs import MySQLToGCSOperator
 
 TASK_ID = 'test-mysql-to-gcs'
 MYSQL_CONN_ID = 'mysql_conn_test'
@@ -72,7 +72,7 @@ class TestMySqlToGoogleCloudStorageOperator(unittest.TestCase):
 
     def test_init(self):
         """Test MySqlToGoogleCloudStorageOperator instance is properly initialized."""
-        op = MySqlToGoogleCloudStorageOperator(
+        op = MySQLToGCSOperator(
             task_id=TASK_ID, sql=SQL, bucket=BUCKET, filename=JSON_FILENAME,
             export_format='CSV', field_delimiter='|')
         self.assertEqual(op.task_id, TASK_ID)
@@ -91,7 +91,7 @@ class TestMySqlToGoogleCloudStorageOperator(unittest.TestCase):
         (None, "BYTES", None)
     ])
     def test_convert_type(self, value, schema_type, expected):
-        op = MySqlToGoogleCloudStorageOperator(
+        op = MySQLToGCSOperator(
             task_id=TASK_ID,
             mysql_conn_id=MYSQL_CONN_ID,
             sql=SQL,
@@ -105,7 +105,7 @@ class TestMySqlToGoogleCloudStorageOperator(unittest.TestCase):
     @mock.patch('airflow.operators.sql_to_gcs.GCSHook')
     def test_exec_success_json(self, gcs_hook_mock_class, mysql_hook_mock_class):
         """Test successful run of execute function for JSON"""
-        op = MySqlToGoogleCloudStorageOperator(
+        op = MySQLToGCSOperator(
             task_id=TASK_ID,
             mysql_conn_id=MYSQL_CONN_ID,
             sql=SQL,
@@ -137,7 +137,7 @@ class TestMySqlToGoogleCloudStorageOperator(unittest.TestCase):
     @mock.patch('airflow.operators.sql_to_gcs.GCSHook')
     def test_exec_success_csv(self, gcs_hook_mock_class, mysql_hook_mock_class):
         """Test successful run of execute function for CSV"""
-        op = MySqlToGoogleCloudStorageOperator(
+        op = MySQLToGCSOperator(
             task_id=TASK_ID,
             mysql_conn_id=MYSQL_CONN_ID,
             sql=SQL,
@@ -170,7 +170,7 @@ class TestMySqlToGoogleCloudStorageOperator(unittest.TestCase):
     @mock.patch('airflow.operators.sql_to_gcs.GCSHook')
     def test_exec_success_csv_ensure_utc(self, gcs_hook_mock_class, mysql_hook_mock_class):
         """Test successful run of execute function for CSV"""
-        op = MySqlToGoogleCloudStorageOperator(
+        op = MySQLToGCSOperator(
             task_id=TASK_ID,
             mysql_conn_id=MYSQL_CONN_ID,
             sql=SQL,
@@ -204,7 +204,7 @@ class TestMySqlToGoogleCloudStorageOperator(unittest.TestCase):
     @mock.patch('airflow.operators.sql_to_gcs.GCSHook')
     def test_exec_success_csv_with_delimiter(self, gcs_hook_mock_class, mysql_hook_mock_class):
         """Test successful run of execute function for CSV with a field delimiter"""
-        op = MySqlToGoogleCloudStorageOperator(
+        op = MySQLToGCSOperator(
             task_id=TASK_ID,
             mysql_conn_id=MYSQL_CONN_ID,
             sql=SQL,
@@ -257,7 +257,7 @@ class TestMySqlToGoogleCloudStorageOperator(unittest.TestCase):
 
         gcs_hook_mock.upload.side_effect = _assert_upload
 
-        op = MySqlToGoogleCloudStorageOperator(
+        op = MySQLToGCSOperator(
             task_id=TASK_ID,
             sql=SQL,
             bucket=BUCKET,
@@ -283,7 +283,7 @@ class TestMySqlToGoogleCloudStorageOperator(unittest.TestCase):
 
         gcs_hook_mock.upload.side_effect = _assert_upload
 
-        op = MySqlToGoogleCloudStorageOperator(
+        op = MySQLToGCSOperator(
             task_id=TASK_ID,
             sql=SQL,
             bucket=BUCKET,
@@ -299,7 +299,7 @@ class TestMySqlToGoogleCloudStorageOperator(unittest.TestCase):
     def test_query_with_error(self, mock_gcs_hook, mock_mysql_hook):
         mock_mysql_hook.return_value.get_conn.\
             return_value.cursor.return_value.execute.side_effect = ProgrammingError
-        op = MySqlToGoogleCloudStorageOperator(
+        op = MySQLToGCSOperator(
             task_id=TASK_ID,
             sql=SQL,
             bucket=BUCKET,
@@ -313,7 +313,7 @@ class TestMySqlToGoogleCloudStorageOperator(unittest.TestCase):
     def test_execute_with_query_error(self, mock_gcs_hook, mock_mysql_hook):
         mock_mysql_hook.return_value.get_conn.\
             return_value.cursor.return_value.execute.side_effect = ProgrammingError
-        op = MySqlToGoogleCloudStorageOperator(
+        op = MySQLToGCSOperator(
             task_id=TASK_ID,
             sql=SQL,
             bucket=BUCKET,

--- a/tests/operators/test_postgres_to_gcs.py
+++ b/tests/operators/test_postgres_to_gcs.py
@@ -23,7 +23,7 @@ import pytest
 from mock import patch
 
 from airflow.hooks.postgres_hook import PostgresHook
-from airflow.operators.postgres_to_gcs import PostgresToGoogleCloudStorageOperator
+from airflow.operators.postgres_to_gcs import PostgresToGCSOperator
 
 TABLES = {'postgres_to_gcs_operator', 'postgres_to_gcs_operator_empty'}
 
@@ -78,7 +78,7 @@ class TestPostgresToGoogleCloudStorageOperator(unittest.TestCase):
 
     def test_init(self):
         """Test PostgresToGoogleCloudStorageOperator instance is properly initialized."""
-        op = PostgresToGoogleCloudStorageOperator(
+        op = PostgresToGCSOperator(
             task_id=TASK_ID, sql=SQL, bucket=BUCKET, filename=FILENAME)
         self.assertEqual(op.task_id, TASK_ID)
         self.assertEqual(op.sql, SQL)
@@ -88,7 +88,7 @@ class TestPostgresToGoogleCloudStorageOperator(unittest.TestCase):
     @patch('airflow.operators.sql_to_gcs.GCSHook')
     def test_exec_success(self, gcs_hook_mock_class):
         """Test the execute function in case where the run is successful."""
-        op = PostgresToGoogleCloudStorageOperator(
+        op = PostgresToGCSOperator(
             task_id=TASK_ID,
             postgres_conn_id=POSTGRES_CONN_ID,
             sql=SQL,
@@ -128,7 +128,7 @@ class TestPostgresToGoogleCloudStorageOperator(unittest.TestCase):
 
         gcs_hook_mock.upload.side_effect = _assert_upload
 
-        op = PostgresToGoogleCloudStorageOperator(
+        op = PostgresToGCSOperator(
             task_id=TASK_ID,
             sql=SQL,
             bucket=BUCKET,
@@ -149,7 +149,7 @@ class TestPostgresToGoogleCloudStorageOperator(unittest.TestCase):
 
         gcs_hook_mock.upload.side_effect = _assert_upload
 
-        op = PostgresToGoogleCloudStorageOperator(
+        op = PostgresToGCSOperator(
             task_id=TASK_ID,
             sql=SQL,
             bucket=BUCKET,


### PR DESCRIPTION
PR contains changes regarding AIP-21 (renaming GCP operators and hooks):
* renamed GCP modules
* adde deprecation warnings to the contrib modules
* fixed tests
* updated UPDATING.md
---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-6145]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
