### PR TITLE
[AIRFLOW-6146] Rename GCS BigQuery, Google Drive, and SFTP operators

### DIFF
--- a/airflow/contrib/example_dags/example_gcs_to_gdrive.py
+++ b/airflow/contrib/example_dags/example_gcs_to_gdrive.py
@@ -22,7 +22,7 @@ Example DAG using GoogleCloudStorageToGoogleDriveOperator.
 import os
 
 from airflow import models
-from airflow.contrib.operators.gcs_to_gdrive_operator import GcsToGDriveOperator
+from airflow.contrib.operators.gcs_to_gdrive_operator import GCSToGoogleDriveOperator
 from airflow.utils.dates import days_ago
 
 GCS_TO_GDRIVE_BUCKET = os.environ.get("GCS_TO_DRIVE_BUCKET", "example-object")
@@ -33,7 +33,7 @@ with models.DAG(
     "example_gcs_to_gdrive", default_args=default_args, schedule_interval=None  # Override to match your needs
 ) as dag:
     # [START howto_operator_gcs_to_gdrive_copy_single_file]
-    copy_single_file = GcsToGDriveOperator(
+    copy_single_file = GCSToGoogleDriveOperator(
         task_id="copy_single_file",
         source_bucket=GCS_TO_GDRIVE_BUCKET,
         source_object="sales/january.avro",
@@ -41,7 +41,7 @@ with models.DAG(
     )
     # [END howto_operator_gcs_to_gdrive_copy_single_file]
     # [START howto_operator_gcs_to_gdrive_copy_files]
-    copy_files = GcsToGDriveOperator(
+    copy_files = GCSToGoogleDriveOperator(
         task_id="copy_files",
         source_bucket=GCS_TO_GDRIVE_BUCKET,
         source_object="sales/*",
@@ -49,7 +49,7 @@ with models.DAG(
     )
     # [END howto_operator_gcs_to_gdrive_copy_files]
     # [START howto_operator_gcs_to_gdrive_move_files]
-    move_files = GcsToGDriveOperator(
+    move_files = GCSToGoogleDriveOperator(
         task_id="move_files",
         source_bucket=GCS_TO_GDRIVE_BUCKET,
         source_object="sales/*.avro",

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -22,10 +22,24 @@ This module is deprecated. Please use `airflow.operators.gcs_to_bq`.
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.operators.gcs_to_bq import GoogleCloudStorageToBigQueryOperator  # noqa
+from airflow.operators.gcs_to_bq import GCSToBigQueryOperator
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.gcs_to_bq`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class GoogleCloudStorageToBigQueryOperator(GCSToBigQueryOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.gcs_to_bq.GCSToBigQueryOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.gcs_to_bq.GCSToBigQueryOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcs_to_gdrive_operator.py
+++ b/airflow/contrib/operators/gcs_to_gdrive_operator.py
@@ -31,7 +31,7 @@ from airflow.utils.decorators import apply_defaults
 WILDCARD = "*"
 
 
-class GcsToGDriveOperator(BaseOperator):
+class GCSToGoogleDriveOperator(BaseOperator):
     """
     Copies objects from a Google Cloud Storage service service to Google Drive service, with renaming
     if requested.

--- a/airflow/example_dags/example_gcs_to_bq.py
+++ b/airflow/example_dags/example_gcs_to_bq.py
@@ -21,7 +21,7 @@ Example DAG using GoogleCloudStorageToBigQueryOperator.
 """
 from airflow import models
 from airflow.operators import bash_operator
-from airflow.operators.gcs_to_bq import GoogleCloudStorageToBigQueryOperator
+from airflow.operators.gcs_to_bq import GCSToBigQueryOperator
 from airflow.utils.dates import days_ago
 
 args = {
@@ -39,7 +39,7 @@ create_test_dataset = bash_operator.BashOperator(
     dag=dag)
 
 # [START howto_operator_gcs_to_bq]
-load_csv = GoogleCloudStorageToBigQueryOperator(
+load_csv = GCSToBigQueryOperator(
     task_id='gcs_to_bq_example',
     bucket='cloud-samples-data',
     source_objects=['bigquery/us-states/us-states.csv'],

--- a/airflow/example_dags/example_gcs_to_sftp.py
+++ b/airflow/example_dags/example_gcs_to_sftp.py
@@ -23,7 +23,7 @@ Example Airflow DAG for Google Cloud Storage to SFTP transfer operators.
 import os
 
 from airflow import models
-from airflow.operators.gcs_to_sftp import GoogleCloudStorageToSFTPOperator
+from airflow.operators.gcs_to_sftp import GCSToSFTPOperator
 from airflow.utils.dates import days_ago
 
 default_args = {"start_date": days_ago(1)}
@@ -40,7 +40,7 @@ with models.DAG(
     "example_gcs_to_sftp", default_args=default_args, schedule_interval=None, tags=['example']
 ) as dag:
     # [START howto_operator_gcs_to_sftp_copy_single_file]
-    copy_file_from_gcs_to_sftp = GoogleCloudStorageToSFTPOperator(
+    copy_file_from_gcs_to_sftp = GCSToSFTPOperator(
         task_id="file-copy-gsc-to-sftp",
         source_bucket=BUCKET_SRC,
         source_object=OBJECT_SRC_1,
@@ -49,7 +49,7 @@ with models.DAG(
     # [END howto_operator_gcs_to_sftp_copy_single_file]
 
     # [START howto_operator_gcs_to_sftp_move_single_file_destination]
-    move_file_from_gcs_to_sftp = GoogleCloudStorageToSFTPOperator(
+    move_file_from_gcs_to_sftp = GCSToSFTPOperator(
         task_id="file-move-gsc-to-sftp",
         source_bucket=BUCKET_SRC,
         source_object=OBJECT_SRC_2,
@@ -59,7 +59,7 @@ with models.DAG(
     # [END howto_operator_gcs_to_sftp_move_single_file_destination]
 
     # [START howto_operator_gcs_to_sftp_copy_directory]
-    copy_dir_from_gcs_to_sftp = GoogleCloudStorageToSFTPOperator(
+    copy_dir_from_gcs_to_sftp = GCSToSFTPOperator(
         task_id="dir-copy-gsc-to-sftp",
         source_bucket=BUCKET_SRC,
         source_object=OBJECT_SRC_3,
@@ -68,7 +68,7 @@ with models.DAG(
     # [END howto_operator_gcs_to_sftp_copy_directory]
 
     # [START howto_operator_gcs_to_sftp_move_specific_files]
-    move_dir_from_gcs_to_sftp = GoogleCloudStorageToSFTPOperator(
+    move_dir_from_gcs_to_sftp = GCSToSFTPOperator(
         task_id="dir-move-gsc-to-sftp",
         source_bucket=BUCKET_SRC,
         source_object=OBJECT_SRC_3,

--- a/airflow/operators/gcs_to_bq.py
+++ b/airflow/operators/gcs_to_bq.py
@@ -30,7 +30,7 @@ from airflow.utils.decorators import apply_defaults
 
 
 # pylint: disable=too-many-instance-attributes
-class GoogleCloudStorageToBigQueryOperator(BaseOperator):
+class GCSToBigQueryOperator(BaseOperator):
     """
     Loads files from Google Cloud Storage into BigQuery.
 

--- a/airflow/operators/gcs_to_sftp.py
+++ b/airflow/operators/gcs_to_sftp.py
@@ -32,13 +32,13 @@ from airflow.utils.decorators import apply_defaults
 WILDCARD = "*"
 
 
-class GoogleCloudStorageToSFTPOperator(BaseOperator):
+class GCSToSFTPOperator(BaseOperator):
     """
     Transfer files from a Google Cloud Storage bucket to SFTP server.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GoogleCloudStorageToSFTPOperator`
+        :ref:`howto/operator:GCSToSFTPOperator`
 
     :param source_bucket: The source Google Cloud Storage bucket where the
          object is. (templated)

--- a/docs/howto/operator/gcp/gcs_to_gdrive.rst
+++ b/docs/howto/operator/gcp/gcs_to_gdrive.rst
@@ -35,16 +35,16 @@ Prerequisite Tasks
 
 .. include:: _partials/prerequisite_tasks.rst
 
-.. _howto/operator:GcsToGDriveOperator:
+.. _howto/operator:GCSToGoogleDriveOperator:
 
 Operator
 ^^^^^^^^
 
 Transfer files between Google Storage and Google Drive is performed with the
-:class:`~airflow.contrib.operators.gcs_to_gdrive_operator.GcsToGDriveOperator` operator.
+:class:`~airflow.contrib.operators.gcs_to_gdrive_operator.GCSToGoogleDriveOperator` operator.
 
 You can use :ref:`Jinja templating <jinja-templating>` with
-:template-fields:`airflow.contrib.operators.gcs_to_gdrive_operator.GcsToGDriveOperator`
+:template-fields:`airflow.contrib.operators.gcs_to_gdrive_operator.GCSToGoogleDriveOperator`
 parameters which allows you to dynamically determine values.
 
 Copy single files

--- a/docs/howto/operator/gcp/gcs_to_sftp.rst
+++ b/docs/howto/operator/gcp/gcs_to_sftp.rst
@@ -34,17 +34,17 @@ Prerequisite Tasks
 
 .. include:: _partials/prerequisite_tasks.rst
 
-.. _howto/operator:GoogleCloudStorageToSFTPOperator:
+.. _howto/operator:GCSToSFTPOperator:
 
 
 Operator
 ^^^^^^^^
 
 Transfer files between SFTP and Google Storage is performed with the
-:class:`~airflow.operators.gcs_to_sftp.GoogleCloudStorageToSFTPOperator` operator.
+:class:`~airflow.operators.gcs_to_sftp.GCSToSFTPOperator` operator.
 
 Use :ref:`Jinja templating <jinja-templating>` with
-:template-fields:`airflow.operators.gcs_to_sftp.GoogleCloudStorageToSFTPOperator`
+:template-fields:`airflow.operators.gcs_to_sftp.GCSToSFTPOperator`
 to define values dynamically.
 
 

--- a/tests/contrib/operators/test_gcs_to_gdrive.py
+++ b/tests/contrib/operators/test_gcs_to_gdrive.py
@@ -20,7 +20,7 @@ import unittest
 from unittest import mock
 
 from airflow import AirflowException
-from airflow.contrib.operators.gcs_to_gdrive_operator import GcsToGDriveOperator
+from airflow.contrib.operators.gcs_to_gdrive_operator import GCSToGoogleDriveOperator
 
 MODULE = "airflow.contrib.operators.gcs_to_gdrive_operator"
 
@@ -33,7 +33,7 @@ class TestGcsToGDriveOperator(unittest.TestCase):
         type(mock_named_temporary_file.return_value.__enter__.return_value).name = mock.PropertyMock(
             side_effect=["TMP1"]
         )
-        task = GcsToGDriveOperator(
+        task = GCSToGoogleDriveOperator(
             task_id="copy_single_file",
             source_bucket="data",
             source_object="sales/sales-2017/january.avro",
@@ -70,7 +70,7 @@ class TestGcsToGDriveOperator(unittest.TestCase):
             side_effect=["TMP1", "TMP2", "TMP3"]
         )
 
-        task = GcsToGDriveOperator(
+        task = GCSToGoogleDriveOperator(
             task_id="copy_files",
             source_bucket="data",
             source_object="sales/sales-2017/*.avro",
@@ -105,7 +105,7 @@ class TestGcsToGDriveOperator(unittest.TestCase):
             side_effect=["TMP1", "TMP2", "TMP3"]
         )
         mock_gcs_hook.return_value.list.return_value = ["sales/A.avro", "sales/B.avro", "sales/C.avro"]
-        task = GcsToGDriveOperator(
+        task = GCSToGoogleDriveOperator(
             task_id="move_files",
             source_bucket="data",
             source_object="sales/sales-2017/*.avro",
@@ -141,7 +141,7 @@ class TestGcsToGDriveOperator(unittest.TestCase):
     def test_should_raise_exception_on_multiple_wildcard(
         self, mock_named_temporary_file, mock_gdrive, mock_gcs_hook
     ):
-        task = GcsToGDriveOperator(
+        task = GCSToGoogleDriveOperator(
             task_id="move_files", source_bucket="data", source_object="sales/*/*.avro", move_object=True
         )
         with self.assertRaisesRegex(AirflowException, "Only one wildcard"):

--- a/tests/operators/test_gcs_to_sftp.py
+++ b/tests/operators/test_gcs_to_sftp.py
@@ -24,7 +24,7 @@ import unittest
 import mock
 
 from airflow.exceptions import AirflowException
-from airflow.operators.gcs_to_sftp import GoogleCloudStorageToSFTPOperator
+from airflow.operators.gcs_to_sftp import GCSToSFTPOperator
 
 TASK_ID = "test-gcs-to-sftp-operator"
 GCP_CONN_ID = "GCP_CONN_ID"
@@ -50,7 +50,7 @@ class TestGoogleCloudStorageToSFTPOperator(unittest.TestCase):
     @mock.patch("airflow.operators.gcs_to_sftp.GCSHook")
     @mock.patch("airflow.operators.gcs_to_sftp.SFTPHook")
     def test_execute_copy_single_file(self, sftp_hook, gcs_hook):
-        task = GoogleCloudStorageToSFTPOperator(
+        task = GCSToSFTPOperator(
             task_id=TASK_ID,
             source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_NO_WILDCARD,
@@ -80,7 +80,7 @@ class TestGoogleCloudStorageToSFTPOperator(unittest.TestCase):
     @mock.patch("airflow.operators.gcs_to_sftp.GCSHook")
     @mock.patch("airflow.operators.gcs_to_sftp.SFTPHook")
     def test_execute_move_single_file(self, sftp_hook, gcs_hook):
-        task = GoogleCloudStorageToSFTPOperator(
+        task = GCSToSFTPOperator(
             task_id=TASK_ID,
             source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_NO_WILDCARD,
@@ -113,7 +113,7 @@ class TestGoogleCloudStorageToSFTPOperator(unittest.TestCase):
     @mock.patch("airflow.operators.gcs_to_sftp.SFTPHook")
     def test_execute_copy_with_wildcard(self, sftp_hook, gcs_hook):
         gcs_hook.return_value.list.return_value = SOURCE_FILES_LIST[:2]
-        operator = GoogleCloudStorageToSFTPOperator(
+        operator = GCSToSFTPOperator(
             task_id=TASK_ID,
             source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_WILDCARD_FILENAME,
@@ -140,7 +140,7 @@ class TestGoogleCloudStorageToSFTPOperator(unittest.TestCase):
     @mock.patch("airflow.operators.gcs_to_sftp.SFTPHook")
     def test_execute_move_with_wildcard(self, sftp_hook, gcs_hook):
         gcs_hook.return_value.list.return_value = SOURCE_FILES_LIST[:2]
-        operator = GoogleCloudStorageToSFTPOperator(
+        operator = GCSToSFTPOperator(
             task_id=TASK_ID,
             source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_WILDCARD_FILENAME,
@@ -164,7 +164,7 @@ class TestGoogleCloudStorageToSFTPOperator(unittest.TestCase):
     @mock.patch("airflow.operators.gcs_to_sftp.SFTPHook")
     def test_execute_more_than_one_wildcard_exception(self, sftp_hook, gcs_hook):
         gcs_hook.return_value.list.return_value = SOURCE_FILES_LIST[:2]
-        operator = GoogleCloudStorageToSFTPOperator(
+        operator = GCSToSFTPOperator(
             task_id=TASK_ID,
             source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_MULTIPLE_WILDCARDS,

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -627,7 +627,7 @@ OPERATOR = [
         "CloudVisionRemoveProductFromProductSetOperator",
     ),
     (
-        "airflow.operators.gcs_to_bq.GoogleCloudStorageToBigQueryOperator",
+        "airflow.operators.gcs_to_bq.GCSToBigQueryOperator",
         "airflow.contrib.operators.gcs_to_bq.GoogleCloudStorageToBigQueryOperator",
     ),
     (


### PR DESCRIPTION
PR contains changes regarding AIP-21 (renaming GCP operators and hooks):
* renamed GCP modules
* adde deprecation warnings to the contrib modules
* fixed tests
* updated UPDATING.md


---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

- [ ] Description above provides context of the change
- [ ] Commit message/PR title starts with `[AIRFLOW-6146]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
