### PR TITLE
[AIRFLOW-6590] Add SQL queries logging

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -169,8 +169,6 @@ def task_run(args, dag=None):
 
     task = dag.get_task(task_id=args.task_id)
     ti = TaskInstance(task, args.execution_date)
-    ti.refresh_from_db()
-
     ti.init_run_context(raw=args.raw)
 
     hostname = get_hostname()

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -495,6 +495,13 @@
       type: string
       example: ~
       default: "False"
+    - name: sqlalchemy_stats
+      description: |
+        Set to True to enable logging of SQLAlchemy queries and execution times.
+      version_added: ~
+      type: string
+      example: ~
+      default: "False"
 - name: api
   description: ~
   options:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -263,6 +263,9 @@ endpoint_url = http://localhost:8080
 # failed task. Helpful for debugging purposes.
 fail_fast = False
 
+# Set to True to enable logging of SQLAlchemy queries and execution times.
+sqlalchemy_stats = False
+
 [api]
 # How to authenticate users of the API
 auth_backend = airflow.api.auth.backend.default

--- a/airflow/example_dags/example_bash_operator.py
+++ b/airflow/example_dags/example_bash_operator.py
@@ -70,5 +70,6 @@ also_run_this = BashOperator(
 # [END howto_operator_bash_template]
 also_run_this >> run_this_last
 
-if __name__ == "__main__":
-    dag.cli()
+if __name__ == '__main__':
+    dag.clear(reset_dag_runs=True)
+    dag.run()

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -31,9 +31,10 @@ from urllib.parse import quote
 import dill
 import lazy_object_proxy
 import pendulum
-from sqlalchemy import Column, Float, Index, Integer, PickleType, String, func
+from sqlalchemy import Column, Float, Index, Integer, PickleType, String, and_, func, or_
 from sqlalchemy.orm import reconstructor
 from sqlalchemy.orm.session import Session
+from sqlalchemy.sql.elements import BooleanClauseList
 
 from airflow import settings
 from airflow.configuration import conf
@@ -1523,6 +1524,29 @@ class TaskInstance(Base, LoggingMixin):
         """
         self.raw = raw
         self._set_context(self)
+
+    @staticmethod
+    def filter_for_tis(
+        tis: Iterable[Union["TaskInstance", TaskInstanceKeyType]]
+    ) -> Optional[BooleanClauseList]:
+        """Returns SQLAlchemy filter to query selected task instances"""
+        TI = TaskInstance
+        if not tis:
+            return None
+        if all(isinstance(t, tuple) for t in tis):
+            filter_for_tis = ([and_(TI.dag_id == dag_id,
+                                    TI.task_id == task_id,
+                                    TI.execution_date == execution_date)
+                               for dag_id, task_id, execution_date, _ in tis])
+            return or_(*filter_for_tis)
+        if all(isinstance(t, TaskInstance) for t in tis):
+            filter_for_tis = ([and_(TI.dag_id == ti.dag_id,  # type: ignore
+                                    TI.task_id == ti.task_id,  # type: ignore
+                                    TI.execution_date == ti.execution_date)  # type: ignore
+                               for ti in tis])
+            return or_(*filter_for_tis)
+
+        raise AirflowException("All elements must have the same type: `TaskInstance` or `TaskInstanceKey`.")
 
 
 # State of the task instance.

--- a/airflow/utils/sqlalchemy.py
+++ b/airflow/utils/sqlalchemy.py
@@ -20,13 +20,18 @@ import datetime
 import json
 import logging
 import os
+import time
+import traceback
 
 import pendulum
 from dateutil import relativedelta
 from sqlalchemy import event, exc
 from sqlalchemy.types import DateTime, Text, TypeDecorator
 
+from airflow.configuration import conf
+
 log = logging.getLogger(__name__)
+
 utc = pendulum.timezone('UTC')
 
 
@@ -34,13 +39,14 @@ def setup_event_handlers(engine):
     """
     Setups event handlers.
     """
+    # pylint: disable=unused-argument
     @event.listens_for(engine, "connect")
-    def connect(dbapi_connection, connection_record):  # pylint: disable=unused-argument
+    def connect(dbapi_connection, connection_record):
         connection_record.info['pid'] = os.getpid()
 
     if engine.dialect.name == "sqlite":
         @event.listens_for(engine, "connect")
-        def set_sqlite_pragma(dbapi_connection, connection_record):  # pylint: disable=unused-argument
+        def set_sqlite_pragma(dbapi_connection, connection_record):
             cursor = dbapi_connection.cursor()
             cursor.execute("PRAGMA foreign_keys=ON")
             cursor.close()
@@ -48,13 +54,13 @@ def setup_event_handlers(engine):
     # this ensures sanity in mysql when storing datetimes (not required for postgres)
     if engine.dialect.name == "mysql":
         @event.listens_for(engine, "connect")
-        def set_mysql_timezone(dbapi_connection, connection_record):  # pylint: disable=unused-argument
+        def set_mysql_timezone(dbapi_connection, connection_record):
             cursor = dbapi_connection.cursor()
             cursor.execute("SET time_zone = '+00:00'")
             cursor.close()
 
     @event.listens_for(engine, "checkout")
-    def checkout(dbapi_connection, connection_record, connection_proxy):  # pylint: disable=unused-argument
+    def checkout(dbapi_connection, connection_record, connection_proxy):
         pid = os.getpid()
         if connection_record.info['pid'] != pid:
             connection_record.connection = connection_proxy.connection = None
@@ -62,6 +68,25 @@ def setup_event_handlers(engine):
                 "Connection record belongs to pid {}, "
                 "attempting to check out in pid {}".format(connection_record.info['pid'], pid)
             )
+    if conf.getboolean('debug', 'sqlalchemy_stats', fallback=False):
+        @event.listens_for(engine, "before_cursor_execute")
+        def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+            conn.info.setdefault('query_start_time', []).append(time.time())
+
+        @event.listens_for(engine, "after_cursor_execute")
+        def after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+            total = time.time() - conn.info['query_start_time'].pop(-1)
+            file_name = [
+                f"'{f.name}':{f.filename}:{f.lineno}" for f
+                in traceback.extract_stack() if 'sqlalchemy' not in f.filename][-1]
+            stack = [f for f in traceback.extract_stack() if 'sqlalchemy' not in f.filename]
+            stack_info = ">".join([f"{f.filename.rpartition('/')[-1]}:{f.name}" for f in stack][-3:])
+            conn.info.setdefault('query_start_time', []).append(time.time())
+            log.info("@SQLALCHEMY %s |$ %s |$ %s |$  %s ",
+                     total, file_name, stack_info, statement.replace("\n", " ")
+                     )
+
+# pylint: enable=unused-argument
 
 
 class UtcDateTime(TypeDecorator):

--- a/scripts/perf/dags/sql_perf_dag.py
+++ b/scripts/perf/dags/sql_perf_dag.py
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.python_operator import PythonOperator
+
+default_args = {
+    "owner": "Airflow",
+    "depends_on_past": False,
+    "start_date": datetime(year=2020, month=1, day=13),
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+}
+
+_FIRST_LEVEL_TASKS = 10
+_SECOND_LEVEL_TASKS = 10
+DAG_ID = f"big_dag_{_FIRST_LEVEL_TASKS}-{_SECOND_LEVEL_TASKS}"
+
+dag = DAG(
+    DAG_ID,
+    default_args=default_args,
+    catchup=True,
+    schedule_interval=timedelta(minutes=1),
+    is_paused_upon_creation=False,
+)
+
+
+def print_context(ds, ti, **kwargs):
+    print("Running %s %s", ti.task_id, ti.execution_date)
+    return "Whatever you return gets printed in the logs"
+
+
+def generate_parallel_tasks(name_prefix, num_of_tasks, deps):
+    tasks = []
+    for t_id in range(num_of_tasks):
+        run_this = PythonOperator(
+            task_id="%s_%s" % (name_prefix, t_id),
+            python_callable=print_context,
+            dag=dag,
+        )
+        run_this.set_upstream(deps)
+        tasks.append(run_this)
+    return tasks
+
+
+zero_level_tasks = generate_parallel_tasks("l0", 1, [])
+first_level_tasks = generate_parallel_tasks("l1", _FIRST_LEVEL_TASKS, zero_level_tasks)
+second_level_tasks = generate_parallel_tasks(
+    "l2", _SECOND_LEVEL_TASKS, first_level_tasks
+)

--- a/scripts/perf/sql_queries.py
+++ b/scripts/perf/sql_queries.py
@@ -1,0 +1,178 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+from time import sleep, time
+from typing import List, NamedTuple, Optional, Tuple
+
+import pandas as pd
+
+# Setup environment before any Airflow import
+DAG_FOLDER = "/opt/airflow/scripts/perf/dags"
+os.environ["AIRFLOW__CORE__DAGS_FOLDER"] = DAG_FOLDER
+os.environ["AIRFLOW__DEBUG__SQLALCHEMY_STATS"] = "True"
+os.environ["AIRFLOW__CORE__LOAD_EXAMPLES"] = "False"
+
+# Here we setup simpler logger to avoid any code changes in
+# Airflow core code base
+LOG_LEVEL = "INFO"
+LOG_FILE = "/files/sql_stats.log"  # Default to run in Breeze
+
+os.environ[
+    "AIRFLOW__LOGGING__LOGGING_CONFIG_CLASS"
+] = "scripts.perf.sql_queries.DEBUG_LOGGING_CONFIG"
+
+DEBUG_LOGGING_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {"airflow": {"format": "%(message)s"}},
+    "handlers": {
+        "console": {"class": "logging.StreamHandler"},
+        "task": {
+            "class": "logging.FileHandler",
+            "formatter": "airflow",
+            "filename": LOG_FILE,
+        },
+        "processor": {
+            "class": "logging.FileHandler",
+            "formatter": "airflow",
+            "filename": LOG_FILE,
+        },
+    },
+    "loggers": {
+        "airflow.processor": {
+            "handlers": ["processor"],
+            "level": LOG_LEVEL,
+            "propagate": False,
+        },
+        "airflow.task": {"handlers": ["task"], "level": LOG_LEVEL, "propagate": False},
+        "flask_appbuilder": {
+            "handler": ["console"],
+            "level": LOG_LEVEL,
+            "propagate": True,
+        },
+    },
+    "root": {"handlers": ["console", "task"], "level": LOG_LEVEL},
+}
+
+
+class Query(NamedTuple):
+    function: str
+    file: str
+    location: int
+    sql: str
+    stack: str
+    time: float
+
+    def __str__(self):
+        sql = self.sql if len(self.sql) < 110 else f"{self.sql[:111]}..."
+        return f"{self.function} in {self.file}:{self.location}: {sql}"
+
+    def __eq__(self, other):
+        return (
+            self.function == other.function
+            and self.sql == other.sql
+            and self.location == other.location
+            and self.file == other.file
+        )
+
+    def to_dict(self):
+        return dict(zip(("function", "file", "location", "sql", "stack", "time"), self))
+
+
+def reset_db():
+    from airflow.utils.db import resetdb
+
+    resetdb()
+
+
+def run_scheduler_job(with_db_reset=False) -> None:
+    from airflow.jobs.scheduler_job import SchedulerJob
+
+    if with_db_reset:
+        reset_db()
+    SchedulerJob(subdir=DAG_FOLDER, do_pickle=False, num_runs=3).run()
+
+
+def is_query(line: str) -> bool:
+    return "@SQLALCHEMY" in line and "|$" in line
+
+
+def make_report() -> List[Query]:
+    queries = []
+    with open(LOG_FILE, "r+") as f:
+        raw_queries = [line for line in f.readlines() if is_query(line)]
+
+    for query in raw_queries:
+        t, info, stack, sql = query.replace("@SQLALCHEMY ", "").split("|$")
+        func, file, loc = info.split(":")
+        file_name = file.rpartition("/")[-1] if "/" in file else file
+        queries.append(
+            Query(
+                function=func.strip(),
+                file=file_name.strip(),
+                location=int(loc.strip()),
+                sql=sql.strip(),
+                stack=stack.strip(),
+                time=float(t.strip()),
+            )
+        )
+
+    return queries
+
+
+def run_test() -> Tuple[List[Query], float]:
+    if os.path.exists(LOG_FILE):
+        os.remove(LOG_FILE)
+
+    tic = time()
+    run_scheduler_job(with_db_reset=False)
+    toc = time()
+    queries = make_report()
+    return queries, toc - tic
+
+
+def rows_to_csv(rows: List[dict], name: Optional[str] = None) -> pd.DataFrame:
+    df = pd.DataFrame(rows)
+    name = name or f"/files/sql_stats_{int(time())}.csv"
+    df.to_csv(name, index=False)
+    print(f"Saved result to {name}")
+    return df
+
+
+def main() -> None:
+    reset_db()
+    rows = []
+    times = []
+
+    for i in range(4):
+        sleep(5)
+        queries, exec_time = run_test()
+        if i == 0:
+            continue
+        times.append(exec_time)
+        for qry in queries:
+            info = qry.to_dict()
+            info["test_no"] = i  # type: ignore
+            rows.append(info)
+
+    rows_to_csv(rows, name="/files/sql_after_remote.csv")
+    print(times)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -227,15 +227,14 @@ class TestDagRun(unittest.TestCase):
                                execution_date=now,
                                start_date=now)
 
+        dr.update_state()
+        self.assertEqual(dr.state, State.RUNNING)
+
         ti_op1 = dr.get_task_instance(task_id=op1.task_id)
         ti_op1.set_state(state=State.SUCCESS, session=session)
         ti_op2 = dr.get_task_instance(task_id=op2.task_id)
         ti_op2.set_state(state=State.NONE, session=session)
 
-        dr.update_state()
-        self.assertEqual(dr.state, State.RUNNING)
-
-        ti_op2.set_state(state=State.NONE, session=session)
         op2.trigger_rule = 'invalid'
         dr.update_state()
         self.assertEqual(dr.state, State.FAILED)


### PR DESCRIPTION
The PR changes numerous single selects / updates in base, scheduler, and backfill jobs to bulk operations.

### Measure
To measure the number of SQL queries I required two things:
- SQLAlchemy callbacks that log query information. This callback can be turned on / off by specifying `sqlalchemy_stats` in `debug` section of Airflow config.
```
@SQLALCHEMY 0.028488636016845703 |$ 'create_session':/opt/airflow/airflow/utils/session.py:32 |$ cli_action_loggers.py:default_action_log>contextlib.py:__exit__>session.py:create_session |$  INSERT INTO log (dttm,...
```
- Script to run successive SchedulerJob and to generate `.csv` with all queries per job. The script is located in `scripts/perf/sql_queries.py` and it works out of the box in the breeze environment.

I am using `SequentialExecutor` and `scripts/perf/dags/sql_perf_dag.py`.

### Results

#### Number of queries
![local2](https://user-images.githubusercontent.com/9528307/73731065-1ee0a180-4738-11ea-9375-87c2eeadf9d0.png)

#### Local database
Number of queries and sum of times [s].
![local](https://user-images.githubusercontent.com/9528307/73731099-2b64fa00-4738-11ea-91c3-6d888e091049.png)

#### Remote cloud database
Number of queries and sum of times [s].
![remote](https://user-images.githubusercontent.com/9528307/73740091-cc0ee600-4747-11ea-9103-c2b310ada97c.png)

As a result, the number of queries was reduced by 18.22% and queries total time by 19.38%. 
