### PR TITLE
Fix confused contrib->core migration direction in tests.

### DIFF
--- a/tests/test_contrib_to_core.py
+++ b/tests/test_contrib_to_core.py
@@ -1599,13 +1599,13 @@ PROTOCOLS = [
 ALL = HOOK + OPERATOR + SENSOR + PROTOCOLS
 
 RENAMED_HOOKS = [
-    (old_class, new_class)
-    for old_class, new_class in HOOK + OPERATOR + SENSOR
+    (new_class, old_class)
+    for new_class, old_class in HOOK + OPERATOR + SENSOR
     if old_class.rpartition(".")[2] != new_class.rpartition(".")[2]
 ]
 
 
-class TestMovingCoreToContrib(TestCase):
+class TestMovingContribToCore(TestCase):
     @staticmethod
     def assert_warning(msg: str, warning: Any):
         error = "Text '{}' not in warnings".format(msg)


### PR DESCRIPTION
---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [ ] Description above provides context of the change
- [ ] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
