### PR TITLE
Kubernetes image is extended rather than customized

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -361,11 +361,6 @@ COPY --chown=airflow:root --from=airflow-build-image /root/.local "${AIRFLOW_USE
 
 COPY scripts/prod/entrypoint_prod.sh /entrypoint
 COPY scripts/prod/clean-logs.sh /clean-logs
-
-ARG EMBEDDED_DAGS="empty"
-
-COPY --chown=airflow:root ${EMBEDDED_DAGS}/ ${AIRFLOW_HOME}/dags/
-
 RUN chmod a+x /entrypoint /clean-logs
 
 # Make /etc/passwd root-group-writeable so that user can be dynamically added by OpenShift

--- a/IMAGES.rst
+++ b/IMAGES.rst
@@ -408,9 +408,6 @@ The following build arguments (``--build-arg`` in docker build command) can be u
 | ``ADDITIONAL_RUNTIME_DEPS``              |                                          | additional apt runtime dependencies to   |
 |                                          |                                          | install                                  |
 +------------------------------------------+------------------------------------------+------------------------------------------+
-| ``EMBEDDED_DAGS``                        | ``empty``                                | Folder containing dags embedded into the |
-|                                          |                                          | image in the ${AIRFLOW_HOME}/dags dir    |
-+------------------------------------------+------------------------------------------+------------------------------------------+
 | ``AIRFLOW_HOME``                         | ``/opt/airflow``                         | Airflow’s HOME (that’s where logs and    |
 |                                          |                                          | sqlite databases are stored)             |
 +------------------------------------------+------------------------------------------+------------------------------------------+

--- a/scripts/ci/kubernetes/ci_deploy_app_to_kubernetes.sh
+++ b/scripts/ci/kubernetes/ci_deploy_app_to_kubernetes.sh
@@ -32,7 +32,9 @@ trap "${HANDLERS}${HANDLERS:+;}dump_kind_logs" EXIT
 get_environment_for_builds_on_ci
 initialize_kind_variables
 make_sure_kubernetes_tools_are_installed
-build_prod_image_for_kubernetes_tests
+prepare_prod_build
+build_prod_images
+build_image_for_kubernetes_tests
 load_image_to_kind_cluster
 deploy_airflow_with_helm
 forward_port_to_kind_webserver

--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -757,7 +757,6 @@ function build_prod_image() {
         --build-arg AIRFLOW_VERSION="${AIRFLOW_VERSION}" \
         --build-arg AIRFLOW_BRANCH="${AIRFLOW_BRANCH_FOR_PYPI_PRELOADING}" \
         --build-arg AIRFLOW_EXTRAS="${AIRFLOW_EXTRAS}" \
-        --build-arg EMBEDDED_DAGS="${EMBEDDED_DAGS}" \
         --build-arg BUILD_ID="${CI_BUILD_ID}" \
         --build-arg COMMIT_SHA="${COMMIT_SHA}" \
         "${DOCKER_CACHE_PROD_DIRECTIVE[@]}" \

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -214,9 +214,6 @@ function initialize_common_environment {
     # Version of Kubernetes to run
     export KUBERNETES_VERSION="${KUBERNETES_VERSION:=${DEFAULT_KUBERNETES_VERSION}}"
 
-    # folder with DAGs to embed into production image
-    export EMBEDDED_DAGS=${EMBEDDED_DAGS:="empty"}
-
     # Namespace where airflow is installed via helm
     export HELM_AIRFLOW_NAMESPACE="airflow"
 


### PR DESCRIPTION
The EMBEDDED dags were only really useful for testing
but it required to customise built production image
(run with extra --build-arg flag). This is not needed
as it is better to extend the image instead with FROM
and add dags afterwards. This way you do not have
to rebuild the image while iterating on it.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
